### PR TITLE
[WIP] Basic Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.editorconfig
+node_modules
+*.log
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea/
 .tmp/
-node_modules/
+node_modules
 dist/
 *.log
 *.map

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:argon
+
+WORKDIR /tmp
+ADD package.json /tmp/
+RUN npm install
+
+RUN mkdir /app
+WORKDIR /app
+
+ENTRYPOINT ["sh", "docker-entrypoint.sh"]
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+web:
+  build: .
+  command: npm run dev
+  ports:
+    - 80:8000
+    - 8080:8080
+  volumes:
+    - .:/app

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Symlink /tmp/node_modules if necessary
+if [ ! -h 'node_modules' ]; then
+  echo "Symlink preinstalled node_modules from /tmp"
+  ln -s /tmp/node_modules /app/node_modules
+fi
+
+# Add pre-commit git hook
+echo "Add pre-commit git hook"
+echo "#!/bin/sh\n\ndocker exec `hostname` `pwd`/node_modules/pre-commit/hook" > .git/hooks/pre-commit
+chmod a+x .git/hooks/pre-commit
+
+exec "$@"


### PR DESCRIPTION
~~First build the image using `docker-compose build`.~~  First `rm -rf node_modules`. (Thanks @pgoetze for pointing that out) Then build the image using `docker-compose build`. This will:

- Create a new Docker image based on [`node:argon`](https://hub.docker.com/_/node/)
- Runs `npm install` when building the image and keeps installed modules in `/tmp/node_modules`

Then create and start a new container based on the previously built image using `docker-compose up`. This will:

- mount application directory to `/app` inside the container
- create a symbolic link `node_modules` pointing to `/tmp/node_modules` if not already present
- create a pre-commit git hook which invokes `node_modules/pre-commit/hook` inside the container
- run `npm run dev`
- expose port `8000` (babel) on the Docker machine's port `80`
- expose port `8080` (webpack) on the Docker machine's port `8080`

@mattberridge, @pgoetze, @artibella could you please give it a try and also check, whether the pre-commit hook is working properly?