### PR TITLE
Hide progress if petition has no required supporters 

### DIFF
--- a/src/components/PetitionHeader/index.js
+++ b/src/components/PetitionHeader/index.js
@@ -5,18 +5,23 @@ import PetitionInfo from 'components/PetitionInfo';
 import PetitionStats from 'components/PetitionStats';
 import ProgressBar from 'components/ProgressBar';
 
-const PetitionHeader = ({ title, info, supporters, percentComplete }) => (
+const PetitionHeader = ({ title, info, metrics }) => (
   <header className={styles.root}>
     <div className={styles.heading}>
       <Heading1 text={title} />
     </div>
     <div className={styles.info}>
       <PetitionInfo {...info} />
-      <ProgressBar
-        animate
-        percentage={percentComplete}
-      />
-      <PetitionStats {...supporters} />
+      {metrics.supportersMetric.votingActive &&
+        <div className={styles.progress}>
+          <ProgressBar
+            animated
+            percentage={metrics.supportersMetric.percentage}
+            aria={metrics.supportersMetric.aria}
+          />
+          <PetitionStats {...metrics.supportersMetric} />
+        </div>
+      }
     </div>
   </header>
 );

--- a/src/components/PetitionHeader/index.js
+++ b/src/components/PetitionHeader/index.js
@@ -12,15 +12,17 @@ const PetitionHeader = ({ title, info, metrics }) => (
     </div>
     <div className={styles.info}>
       <PetitionInfo {...info} />
-      {metrics.supportersMetric.votingActive &&
-        <div className={styles.progress}>
-          <ProgressBar
-            animated
-            percentage={metrics.supportersMetric.percentage}
-            aria={metrics.supportersMetric.aria}
-          />
-          <PetitionStats {...metrics.supportersMetric} />
-        </div>
+      {
+        metrics.supportersMetric &&
+        metrics.supportersMetric.votingActive &&
+          <div className={styles.progress}>
+            <ProgressBar
+              animated
+              percentage={metrics.supportersMetric.percentage}
+              aria={metrics.supportersMetric.aria}
+            />
+            <PetitionStats {...metrics.supportersMetric} />
+          </div>
       }
     </div>
   </header>

--- a/src/components/PetitionInfo/index.js
+++ b/src/components/PetitionInfo/index.js
@@ -4,12 +4,14 @@ import IconAndInfo from 'components/IconAndInfo';
 
 const PetitionInfo = ({ city, dateRange }) => (
   <ul className={styles.root}>
-    <li className={styles.item}>
-      <IconAndInfo
-        icon='Pin'
-        info={city}
-      />
-    </li>
+    {city &&
+      <li className={styles.item}>
+        <IconAndInfo
+          icon='Pin'
+          info={city}
+        />
+      </li>
+    }
     <li className={styles.item}>
       <IconAndInfo
         icon='Clock'

--- a/src/components/PetitionStats/index.js
+++ b/src/components/PetitionStats/index.js
@@ -2,13 +2,13 @@ import React from 'react';
 import styles from './petition-stats.scss';
 import settings from 'settings';
 
-const PetitionStats = ({ total, required }) => (
+const PetitionStats = ({ figure, total }) => (
   <ul className={styles.root}>
     <li className={styles.item}>
-      {settings.supportersText} <b className={styles.total}>{total}</b>
+      {settings.supportersText} <b className={styles.figure}>{figure}</b>
     </li>
     <li className={styles.item}>
-      {settings.milestoneText} {required}
+      {settings.milestoneText} {total}
     </li>
   </ul>
 );

--- a/src/components/PetitionStats/petition-stats.scss
+++ b/src/components/PetitionStats/petition-stats.scss
@@ -14,6 +14,6 @@
   margin-top: 15px;
 }
 
-.total {
+.figure {
   color: color('primary');
 }

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -1,31 +1,62 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import styles from './progress-bar.scss';
+import settings from 'settings';
+import ProgressBarJS from 'progressbar.js';
 
 const ProgressBar = React.createClass({
+
+  getDefaultProps: () => ({
+    percentage: 0,
+    animated: false,
+    color: settings.colors.primary,
+    trailColor: settings.colors.greyLite,
+    aria: {}
+  }),
+
   componentDidMount () {
-    if (this.props.animate) {
-      setTimeout(() => this.setState({
-        loading: false }),
-      150);
+    this.initProgressBar();
+    this.updateProgressBar(this.props.percentage);
+  },
+
+  initProgressBar () {
+    const canvasElement = ReactDOM.findDOMNode(this.refs.canvas);
+
+    this.progressBar = new ProgressBarJS.Line(canvasElement, {
+      strokeWidth: 4,
+      easing: 'easeInOut',
+      duration: 1500,
+      color: this.props.color,
+      trailColor: this.props.trailColor,
+      trailWidth: 4,
+      svgStyle: {
+        width: '100%',
+        height: '100%'
+      },
+      autoStyleContainer: false
+    });
+  },
+
+  updateProgressBar (percentage) {
+    const progress = percentage / 100;
+
+    if (this.props.animated) {
+      this.progressBar.animate(progress);
+    } else {
+      this.progressBar.set(progress);
     }
   },
 
-  getInitialState: () => ({
-    loading: true
-  }),
-
   render () {
-    const appliedClass = this.state.loading
-      ? styles.loading
-      : styles.finished;
-
     return (
-      <span aria-hidden className={styles.root}>
-        <span
-          className={appliedClass}
-          style={{ width: `${this.props.percentage}%` }}
-        />
-      </span>
+      <div
+        className={styles.root}
+        ref='canvas'
+        role='progressbar'
+        aria-valuenow={this.props.aria.value}
+        aria-valuemin={this.props.aria.minimum}
+        aria-valuemax={this.props.aria.maximum}
+      />
     );
   }
 });

--- a/src/components/ProgressBar/progress-bar.scss
+++ b/src/components/ProgressBar/progress-bar.scss
@@ -3,23 +3,7 @@
 $bar-height: 18px;
 
 .root {
-  height: $bar-height;
   display: block;
-  background-color: color('grey');
-}
-
-.progress {
   height: $bar-height;
-  display: block;
-}
-
-.loading {
-  composes: progress;
-  width: 0 !important;
-}
-
-.finished {
-  composes: progress;
-  background-color: color('primary');
-  transition: width 1.25s ease-out;
+  width: 100%;
 }

--- a/src/components/TeaserMetrics/index.js
+++ b/src/components/TeaserMetrics/index.js
@@ -13,13 +13,16 @@ export default ({ timeMetric, supportersMetric }) => (
           caption={settings.teaserDaysRemaining}
         />
       </div>
-      <div className={styles.metric}>
-        <PetitionMetric
-          {...supportersMetric}
-          icon={'Signature'}
-          caption={settings.teaserSupportersText}
-        />
-      </div>
+
+      {supportersMetric && supportersMetric.votingActive &&
+        <div className={styles.metric}>
+          <PetitionMetric
+            {...supportersMetric}
+            icon={'Signature'}
+            caption={settings.teaserSupportersText}
+          />
+        </div>
+      }
     </div>
   </div>
 );

--- a/src/selectors/petition.js
+++ b/src/selectors/petition.js
@@ -1,5 +1,4 @@
 import getPetitionDateRange from './petitionDateRange';
-import calculatePercentage from 'helpers/calculatePercentage';
 import getPetitionSchema from './petitionSchema';
 import getPetitionMetrics from './petitionMetrics';
 
@@ -8,31 +7,26 @@ export default (petition) => {
     return {};
   }
 
+  const metrics = getPetitionMetrics(petition);
+
   return {
     id: petition.id,
     browserTitle: petition.title,
     schema: getPetitionSchema(petition),
     header: {
       title: petition.title,
-      percentComplete: calculatePercentage(
-        petition.supporters.amount,
-        petition.supporters.required
-      ),
       info: {
         city: petition.city,
         dateRange: getPetitionDateRange(petition.dc || {})
       },
-      supporters: {
-        total: petition.supporters.amount,
-        required: petition.supporters.required
-      }
+      metrics: metrics
     },
     body: {
       description: petition.description,
       suggestedSolution: petition.suggested_solution
     },
     sidebar: {
-      metrics: getPetitionMetrics(petition)
+      metrics: metrics
     }
   };
 };

--- a/src/selectors/petitionMetrics.js
+++ b/src/selectors/petitionMetrics.js
@@ -13,6 +13,7 @@ export default (petition) => {
   const amountVotes = petition.supporters.amount;
   const timePercentage = getTimePercentage(daysRemaining, daysToVote);
   const votesPercentage = calculatePercentage(amountVotes, requiredVotes);
+  // FIXME: change check to -1 when API is behaving this way
   const votingActive = requiredVotes > 0;
 
   return {

--- a/src/selectors/petitionMetrics.js
+++ b/src/selectors/petitionMetrics.js
@@ -13,6 +13,7 @@ export default (petition) => {
   const amountVotes = petition.supporters.amount;
   const timePercentage = getTimePercentage(daysRemaining, daysToVote);
   const votesPercentage = calculatePercentage(amountVotes, requiredVotes);
+  const votingActive = requiredVotes > 0;
 
   return {
     timeMetric: {
@@ -33,7 +34,8 @@ export default (petition) => {
         minimum: 0,
         maximum: requiredVotes,
         value: amountVotes
-      }
+      },
+      votingActive: votingActive
     }
   };
 };

--- a/test/selectors/petitionMetrics.js
+++ b/test/selectors/petitionMetrics.js
@@ -47,5 +47,21 @@ describe('get petiton metrics', () => {
       const actual = metrics.supportersMetric.total;
       assert.isNumber(actual);
     });
+
+    it('voting is enabled if required supporters above 0', () => {
+      const actual = metrics.supportersMetric.votingActive;
+      assert.isTrue(actual);
+    });
+
+    it('voting is disabled if required supporters below 0', () => {
+      const testPetiton = Object.assign({}, petition);
+      let metrics;
+
+      testPetiton.supporters.required = -1;
+      metrics = getPetitionMetrics(testPetiton);
+
+      const actual = metrics.supportersMetric.votingActive;
+      assert.isFalse(actual);
+    });
   });
 });


### PR DESCRIPTION
It is possible to submit petitions without a city. Therefore it won't be possible to display the supporters progress as the required number is defined on city level.

This PR does following:

* Hide supporters progress in teasers
* Hide supporters progress on petition page
* Refactor progress bar to use same logic as circular progress bar
* Refactor petition selector to use petition metrics object for more consistency

