### PR TITLE
Limit Travis CI to build master, develop, staging, and PRs only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: node_js
 node_js:
   - '4'
 
+branches:
+  only:
+    - 'master'
+    - 'develop'
+    - 'staging'
+
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
TravisCI used to run twice on PRs - for the feature branch itself and for the potential merge.

If you see Travis running only once for this PR it works.

@mattberridge, @artibella 