### PR TITLE
[RFR] Add City and Owner to Petition and Petition Listing

### DIFF
--- a/src/components/PetitionInfo/index.js
+++ b/src/components/PetitionInfo/index.js
@@ -2,8 +2,16 @@ import React from 'react';
 import styles from './petition-info.scss';
 import IconAndInfo from 'components/IconAndInfo';
 
-const PetitionInfo = ({ city, dateRange }) => (
+const PetitionInfo = ({ owner, city, dateRange }) => (
   <ul className={styles.root}>
+    {owner &&
+      <li className={styles.item}>
+        <IconAndInfo
+          icon='User'
+          info={owner}
+        />
+      </li>
+    }
     {city &&
       <li className={styles.item}>
         <IconAndInfo

--- a/src/containers/PetitionInfo.js
+++ b/src/containers/PetitionInfo.js
@@ -12,6 +12,7 @@ const mapStateToProps = ({ petition }) => {
 };
 
 PetitionInfoContainer.propTypes = {
+  owner: React.PropTypes.string,
   city: React.PropTypes.string,
   dateRange: React.PropTypes.string
 };

--- a/src/helpers/getPetitionsRequestParams.js
+++ b/src/helpers/getPetitionsRequestParams.js
@@ -5,6 +5,7 @@ export default ({ limit, page }) => {
   const saneLimit = sanitizeParamLimit(limit);
 
   return {
+    resolve: 'city,owner',
     offset: calculateParamOffset(page, saneLimit),
     limit: saneLimit
   };

--- a/src/selectors/petitionCity.js
+++ b/src/selectors/petitionCity.js
@@ -1,0 +1,5 @@
+export default (petition = {}) => {
+  return petition.city &&
+    petition.city.data &&
+    petition.city.data.name;
+};

--- a/src/selectors/petitionCity.js
+++ b/src/selectors/petitionCity.js
@@ -1,5 +1,5 @@
 export default (petition = {}) => {
-  return petition.city &&
-    petition.city.data &&
-    petition.city.data.name;
+  return petition.city && petition.city.data
+    ? petition.city.data.name
+    : '';
 };

--- a/src/selectors/petitionInfo.js
+++ b/src/selectors/petitionInfo.js
@@ -1,8 +1,10 @@
 import getPetitionDateRange from 'helpers/getPetitionDateRange';
+import petitionOwner from './petitionOwner';
 import petitionCity from './petitionCity';
 
 export default (petition = {}) => {
   return {
+    owner: petitionOwner(petition),
     city: petitionCity(petition),
     dateRange: getPetitionDateRange(petition)
   };

--- a/src/selectors/petitionInfo.js
+++ b/src/selectors/petitionInfo.js
@@ -1,8 +1,9 @@
 import getPetitionDateRange from 'helpers/getPetitionDateRange';
+import petitionCity from './petitionCity';
 
 export default (petition = {}) => {
   return {
-    city: petition.city && petition.city.name,
+    city: petitionCity(petition),
     dateRange: getPetitionDateRange(petition)
   };
 };

--- a/src/selectors/petitionOwner.js
+++ b/src/selectors/petitionOwner.js
@@ -1,0 +1,9 @@
+export default (petition = {}) => {
+  if (petition.owner && petition.owner.data) {
+    return [
+      petition.owner.data.firstname,
+      petition.owner.data.lastname
+    ].join(' ');
+  }
+  return '';
+};

--- a/src/selectors/petitionTeaser.js
+++ b/src/selectors/petitionTeaser.js
@@ -1,6 +1,7 @@
 import getAuthorLabel from 'helpers/getAuthorLabel';
 import getPetitionMetrics from './petitionMetrics';
 import petitionCity from './petitionCity';
+import petitionOwner from './petitionOwner';
 
 export default (petition = {}) => {
   if (!petition || !petition.id) {
@@ -12,7 +13,7 @@ export default (petition = {}) => {
     link: `/petitions/${petition.id}`,
     title: petition.title,
     city: petitionCity(petition),
-    owner: getAuthorLabel(petition.owner) || 'Max Mustermann',
+    owner: getAuthorLabel(petitionOwner(petition)),
     metrics: getPetitionMetrics(petition)
   };
 };

--- a/src/selectors/petitionTeaser.js
+++ b/src/selectors/petitionTeaser.js
@@ -1,5 +1,6 @@
 import getAuthorLabel from 'helpers/getAuthorLabel';
 import getPetitionMetrics from './petitionMetrics';
+import petitionCity from './petitionCity';
 
 export default (petition = {}) => {
   if (!petition || !petition.id) {
@@ -10,7 +11,7 @@ export default (petition = {}) => {
     id: petition.id,
     link: `/petitions/${petition.id}`,
     title: petition.title,
-    city: petition.city && petition.city.name,
+    city: petitionCity(petition),
     owner: getAuthorLabel(petition.owner) || 'Max Mustermann',
     metrics: getPetitionMetrics(petition)
   };

--- a/src/services/api/repositories/petition.js
+++ b/src/services/api/repositories/petition.js
@@ -5,7 +5,8 @@ import path from 'path';
 export default {
   find: (id) => {
     const requestPath = path.join('/petitions', id.toString());
-    return ApiClient.request(requestPath);
+    const requestParams = { resolve: 'city,owner' };
+    return ApiClient.request(requestPath, requestParams);
   },
 
   all: (options = {}) => {

--- a/test/helpers/getPetitionsRequestParams.js
+++ b/test/helpers/getPetitionsRequestParams.js
@@ -4,42 +4,53 @@ import getPetitionsRequestParams from 'helpers/getPetitionsRequestParams';
 const { assert } = chai;
 
 describe('getPetitionsRequestParams', () => {
+  it('always returns resolved city and owner', () => {
+    const result = getPetitionsRequestParams({});
+    const actual = result.resolve;
+    const expected = 'city,owner';
+
+    assert.equal(actual, expected);
+  });
+
   it('returns offset and limit correctly', () => {
-    const actual = getPetitionsRequestParams({
+    const result = getPetitionsRequestParams({
       limit: 50,
       page: 1
     });
-    const expected = {
-      offset: 0,
-      limit: 50
-    };
+    const actualOffset = result.offset;
+    const actualLimit = result.limit;
+    const expectedOffset = 0;
+    const expectedLimit = 50;
 
-    assert.deepEqual(actual, expected);
+    assert.equal(actualOffset, expectedOffset);
+    assert.equal(actualLimit, expectedLimit);
   });
 
   it('returns offset and limit correctly', () => {
-    const actual = getPetitionsRequestParams({
+    const result = getPetitionsRequestParams({
       limit: 100,
       page: 6
     });
-    const expected = {
-      offset: 500,
-      limit: 100
-    };
+    const actualOffset = result.offset;
+    const actualLimit = result.limit;
+    const expectedOffset = 500;
+    const expectedLimit = 100;
 
-    assert.deepEqual(actual, expected);
+    assert.equal(actualOffset, expectedOffset);
+    assert.equal(actualLimit, expectedLimit);
   });
 
   it('catches strange offsets and limits', () => {
-    const actual = getPetitionsRequestParams({
+    const result = getPetitionsRequestParams({
       limit: -100,
       page: -6
     });
-    const expected = {
-      offset: 0,
-      limit: 12
-    };
+    const actualOffset = result.offset;
+    const actualLimit = result.limit;
+    const expectedOffset = 0;
+    const expectedLimit = 12;
 
-    assert.deepEqual(actual, expected);
+    assert.equal(actualOffset, expectedOffset);
+    assert.equal(actualLimit, expectedLimit);
   });
 });

--- a/test/mocks/petition.json
+++ b/test/mocks/petition.json
@@ -1,6 +1,24 @@
 {
   "data": {
-    "city": null,
+    "city": {
+      "data": {
+        "name": "Clinemouth",
+        "tags": [
+          "portal:bzb"
+        ],
+        "provider": "test",
+        "zips": [
+          "17839",
+          "30359",
+          "41731",
+          "69846"
+        ],
+        "treshold": 10,
+        "id": "test:27"
+      },
+      "id": "test:27",
+      "class": "City"
+    },
     "connected_locations": [],
     "dc": {
       "created": "2016-01-28T02:54:33",
@@ -12,7 +30,20 @@
     "id": 2,
     "images": [],
     "links": [],
-    "owner": null,
+    "owner": {
+      "data": {
+        "lastname": "Ballard",
+        "state": "active",
+        "id": "1z4ZX",
+        "firstname": "Stephanie",
+        "dc": {
+          "modified": "2016-05-27T16:21:56",
+          "created": "2016-05-27T16:21:56"
+        }
+      },
+      "id": "1z4ZX",
+      "class": "User"
+    },
     "response_token": null,
     "state": "draft",
     "suggested_solution": "Fugiat quibusdam mollitia exercitationem possimus adipisci. Id natus beatae soluta fugiat. Mollitia quos architecto corrupti blanditiis. Nemo magni ratione illum dignissimos enim.\nAliquid saepe nesciunt possimus repudiandae. Itaque est odit dolore reprehenderit non corporis aperiam expedita. Animi doloribus quaerat laborum nostrum similique alias. Ipsum quibusdam modi blanditiis.\nVoluptate labore tempore ullam reiciendis possimus occaecati ab. Quaerat non sapiente consequatur nam. Eum omnis quo porro magnam veniam tempore libero.",

--- a/test/selectors/petitionCity.js
+++ b/test/selectors/petitionCity.js
@@ -1,0 +1,21 @@
+import chai from 'chai';
+import getPetitionCity from 'selectors/petitionCity';
+import mockPetition from '../mocks/petition';
+
+const { assert } = chai;
+
+describe('getPetitionCity', () => {
+  it('returns name correctly', () => {
+    const actual = getPetitionCity(mockPetition.data);
+    const expected = 'Clinemouth';
+
+    assert.equal(actual, expected);
+  });
+
+  it('returns empty string as fallback', () => {
+    const actual = getPetitionCity({});
+    const expected = '';
+
+    assert.equal(actual, expected);
+  });
+});

--- a/test/selectors/petitionOwner.js
+++ b/test/selectors/petitionOwner.js
@@ -1,0 +1,21 @@
+import chai from 'chai';
+import getPetitionOwner from 'selectors/petitionOwner';
+import mockPetition from '../mocks/petition';
+
+const { assert } = chai;
+
+describe('getPetitionOwner', () => {
+  it('returns name correctly', () => {
+    const actual = getPetitionOwner(mockPetition.data);
+    const expected = 'Stephanie Ballard';
+
+    assert.equal(actual, expected);
+  });
+
+  it('returns empty string as fallback', () => {
+    const actual = getPetitionOwner({});
+    const expected = '';
+
+    assert.equal(actual, expected);
+  });
+});

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -55,6 +55,17 @@ describe('petition repository', () => {
         expectedPathArgument
       ));
     });
+
+    it('resolves owner and city', () => {
+      let expectedDataArgument = { resolve: 'city,owner' };
+
+      petitionRepository.find(exampleId);
+
+      assert(ApiClient.request.calledWith(
+        expectedPathArgument,
+        expectedDataArgument
+      ));
+    });
   });
 
   describe('create', () => {

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -20,7 +20,7 @@ describe('petition repository', () => {
 
     context('without any argument', () => {
       it('calls the API client with default offset and limit', () => {
-        let expectedDataArgument = { offset: 0, limit: 12 };
+        let expectedDataArgument = { offset: 0, limit: 12, resolve: 'city,owner' };
 
         petitionRepository.all();
 
@@ -33,7 +33,7 @@ describe('petition repository', () => {
 
     context('with custom pagination argument', () => {
       it('calls the API client with proper offset and limit', () => {
-        let expectedDataArgument = { offset: 10, limit: 10 };
+        let expectedDataArgument = { offset: 10, limit: 10, resolve: 'city,owner' };
 
         petitionRepository.all({ page: 2, limit: 10 });
 


### PR DESCRIPTION
Adds city and owner resolving from API, and selectors to map data onto main Petition page, and teaser (with tests!)

![screen shot 2016-09-01 at 16 47 23](https://cloud.githubusercontent.com/assets/447493/18171804/8372297a-7063-11e6-8519-caa1cd622529.png)
![screen shot 2016-09-01 at 16 47 18](https://cloud.githubusercontent.com/assets/447493/18171805/8376081a-7063-11e6-96cb-8c34f1609c35.png)
