### PR TITLE
[RFR] Success Displays

### DIFF
--- a/src/actions/PetitionActions.js
+++ b/src/actions/PetitionActions.js
@@ -17,6 +17,10 @@ import {
   hideFlashMessage
 } from './FlashActions';
 
+import {
+  showModalWindow
+} from './ModalActions';
+
 export function fetchPetition (id) {
   return (dispatch, getState) => {
     dispatch(requestPetition());
@@ -148,7 +152,7 @@ export function supportPetition (petition, dispatch) {
       .then((response) => dispatch(
         supportedPetition(response.data)
       )).then(() => dispatch(
-        showFlashMessage(settings.flashMessages.petitionSupported, 'success')
+        showModalWindow('supported')
       )).catch(() => dispatch(
         showFlashMessage(settings.flashMessages.genericError, 'error')
       ));

--- a/src/actions/PetitionActions.js
+++ b/src/actions/PetitionActions.js
@@ -1,5 +1,5 @@
 import petitionRepository from 'services/api/repositories/petition';
-import supportCountIncreased from 'helpers/supportCountIncreased';
+import getSupportedPetitionModal from 'helpers/getSupportedPetitionModal';
 import settings from 'settings';
 import {
   REQUEST_PETITION,
@@ -152,15 +152,10 @@ export function supportPetition (petition, dispatch) {
     return petitionRepository.support(petition)
       .then((response) => dispatch(
         supportedPetition(response.data)
-      )).then((response) => dispatch(
-        supportCountIncreased(petition, response.petition)
-          ? showModalWindow({
-            type: 'newlySupported'
-          })
-          : showModalWindow({
-            type: 'alreadySupported'
-          })
-      )).catch(() => dispatch(
+      )).then((response) => dispatch(showModalWindow({
+        type: 'supported',
+        ...getSupportedPetitionModal(petition, response.petition)
+      }))).catch(() => dispatch(
         showFlashMessage(settings.flashMessages.genericError, 'error')
       ));
   };

--- a/src/actions/PetitionActions.js
+++ b/src/actions/PetitionActions.js
@@ -154,8 +154,12 @@ export function supportPetition (petition, dispatch) {
         supportedPetition(response.data)
       )).then((response) => dispatch(
         supportCountIncreased(petition, response.petition)
-          ? showModalWindow('newlySupported')
-          : showModalWindow('alreadySupported')
+          ? showModalWindow({
+            type: 'newlySupported'
+          })
+          : showModalWindow({
+            type: 'alreadySupported'
+          })
       )).catch(() => dispatch(
         showFlashMessage(settings.flashMessages.genericError, 'error')
       ));

--- a/src/actions/PetitionActions.js
+++ b/src/actions/PetitionActions.js
@@ -1,4 +1,5 @@
 import petitionRepository from 'services/api/repositories/petition';
+import supportCountIncreased from 'helpers/supportCountIncreased';
 import settings from 'settings';
 import {
   REQUEST_PETITION,
@@ -151,8 +152,10 @@ export function supportPetition (petition, dispatch) {
     return petitionRepository.support(petition)
       .then((response) => dispatch(
         supportedPetition(response.data)
-      )).then(() => dispatch(
-        showModalWindow('supported')
+      )).then((response) => dispatch(
+        supportCountIncreased(petition, response.petition)
+          ? showModalWindow('newlySupported')
+          : showModalWindow('alreadySupported')
       )).catch(() => dispatch(
         showFlashMessage(settings.flashMessages.genericError, 'error')
       ));

--- a/src/assets/styles/_breakpoints.scss
+++ b/src/assets/styles/_breakpoints.scss
@@ -13,5 +13,6 @@ $breakpoints: (
   'grid-2-cols': 37.5em,
   'grid-3-cols': 56.25em,
   'text-boost': 500px,
-  'form-switch': 800px
+  'form-switch': 800px,
+  'modal-size': 700px
 ) !default;

--- a/src/assets/styles/_layout.scss
+++ b/src/assets/styles/_layout.scss
@@ -29,7 +29,7 @@ $widths: (
   'teaser-max': 320px,
   'fieldset-max': 650px,
   'close-button': 46px,
-  'modal': 550px,
+  'modal': 530px,
   'sidebar-progress': 210px
 ) !default;
 

--- a/src/components/Button/button.scss
+++ b/src/components/Button/button.scss
@@ -5,8 +5,12 @@
   text-decoration: none;
   outline: 0;
 
+  @include media('<=text-boost') {
+    font-size: 16px;
+  }
+
   @include media('>text-boost') {
-    font-size: 1.125em;
+    font-size: 18px;
   }
 }
 

--- a/src/components/Button/button.scss
+++ b/src/components/Button/button.scss
@@ -38,11 +38,6 @@
   composes: shared;
 }
 
-.smaller {
-  @include map-declarations($button-smaller-defaults, $button-smaller-custom);
-  composes: shared;
-}
-
 /*
  * 1. calculated with http://razorjam.github.io/sasscolourfunctioncalculator/
  */

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -3,6 +3,7 @@ import styles from './button.scss';
 
 export const getClassname = ({ disabled, modifier, fill, size }) => {
   return [
+    styles[size || 'default'],
     styles[disabled ? 'disabled' : (modifier || 'default')],
     styles[size],
     styles[fill ? 'block' : 'inline']

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -3,7 +3,7 @@ import styles from './button.scss';
 
 export const getClassname = ({ disabled, modifier, fill, size }) => {
   return [
-    styles[size || 'default'],
+    styles[size || ''],
     styles[disabled ? 'disabled' : (modifier || 'default')],
     styles[size],
     styles[fill ? 'block' : 'inline']

--- a/src/components/Icon/icon.scss
+++ b/src/components/Icon/icon.scss
@@ -22,6 +22,12 @@
   height: 26px;
 }
 
+.huge {
+  composes: root;
+  width: 50px;
+  height: 50px;
+}
+
 .dark {
   fill: color('black');
 }

--- a/src/components/IconBullet/icon-bullet.scss
+++ b/src/components/IconBullet/icon-bullet.scss
@@ -3,8 +3,16 @@
 .root {
   border-radius: 50%;
   position: relative;
+}
+
+.small {
   width: 30px;
   height: 30px;
+}
+
+.huge {
+  width: 100px;
+  height: 100px;
 }
 
 .error {
@@ -26,4 +34,12 @@
 
 .use {
   fill: white;
+}
+
+.inline {
+  display: inline;
+}
+
+.inline-block {
+  display: inline-block;
 }

--- a/src/components/IconBullet/index.js
+++ b/src/components/IconBullet/index.js
@@ -2,13 +2,21 @@ import React from 'react';
 import styles from './icon-bullet.scss';
 import Icon from 'components/Icon';
 
-export default ({ id, modifier }) => (
-  <div className={styles[modifier || 'root']} aria-role={'presentation'}>
+const getClassname = (size, modifier, inline) => {
+  return [
+    styles[size || 'small'],
+    styles[modifier || 'default'],
+    styles[inline ? 'inline' : 'inline-block']
+  ].join(' ');
+};
+
+export default ({ id, modifier, size }) => (
+  <div className={getClassname(modifier, size)} aria-role={'presentation'}>
     <div className={styles.icon}>
       <Icon
         id={id}
         modifier={'invert'}
-        size={'small'}
+        size={size || 'small'}
       />
     </div>
   </div>

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -3,7 +3,7 @@ import styles from './link.scss';
 
 const Link = ({ href, children, text }) => (
   <a href={href} className={styles.root}>
-    {children || text}
+    {children || text || href}
   </a>
 );
 

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './link.scss';
+
+const Link = ({ href, children, text }) => (
+  <a href={href} className={styles.root}>
+    {children || text}
+  </a>
+);
+
+export default Link;

--- a/src/components/Link/link.scss
+++ b/src/components/Link/link.scss
@@ -1,0 +1,16 @@
+@import 'globals';
+
+.root:link,
+.root:visited {
+  padding-bottom: 2px;
+  text-decoration: none;
+  color: color('black');
+  border-bottom: 1px solid blue;
+}
+
+.root:hover,
+.root:active,
+.root:focus {
+  color: color('primary');
+  border-bottom-color: color('primary');
+}

--- a/src/components/ModalIntro/index.js
+++ b/src/components/ModalIntro/index.js
@@ -3,12 +3,14 @@ import styles from './modal-intro.scss';
 import TextCenter from 'components/TextCenter';
 
 const ModalIntro = ({ title, intro }) => (
-  <TextCenter>
-    {title && <h2 className={styles.title}>{title}</h2>}
-    <p className={styles.intro}>
-      {intro}
-    </p>
-  </TextCenter>
+  <div className={styles.root}>
+    <TextCenter>
+      {title && <h2 className={styles.title}>{title}</h2>}
+      <p className={styles.intro}>
+        {intro}
+      </p>
+    </TextCenter>
+  </div>
 );
 
 export default ModalIntro;

--- a/src/components/ModalIntro/modal-intro.scss
+++ b/src/components/ModalIntro/modal-intro.scss
@@ -24,13 +24,14 @@
 .intro {
   color: color('dimmed');
   margin-top: 10px;
-  margin-bottom: 5px;
 
   @include media('<=modal-size') {
     font-size: 18px;
+    margin-bottom: 20px;
   }
 
   @include media('>modal-size') {
     font-size: 20px;
+    margin-bottom: 30px;
   }
 }

--- a/src/components/ModalIntro/modal-intro.scss
+++ b/src/components/ModalIntro/modal-intro.scss
@@ -8,14 +8,16 @@
 .title {
   font-weight: normal;
 
-  @include media('<=700px') {
+  @include media('<=modal-size') {
     padding-left: 20px;
     padding-right: 20px;
     font-size: 24px;
+    margin-bottom: 10px;
   }
 
-  @include media('>700px') {
+  @include media('>modal-size') {
     font-size: 28px;
+    margin-bottom: 20px;
   }
 }
 
@@ -24,11 +26,11 @@
   margin-top: 10px;
   margin-bottom: 5px;
 
-  @include media('<=700px') {
+  @include media('<=modal-size') {
     font-size: 18px;
   }
 
-  @include media('>700px') {
+  @include media('>modal-size') {
     font-size: 20px;
   }
 }

--- a/src/components/ModalIntro/modal-intro.scss
+++ b/src/components/ModalIntro/modal-intro.scss
@@ -1,12 +1,16 @@
 @import 'globals';
 
+.root {
+  line-height: 1.3;
+}
+
 .title {
   font-weight: normal;
-  line-height: 1.3;
 
-  @include media('<700px') {
+  @include media('<=700px') {
     padding-left: 20px;
     padding-right: 20px;
+    font-size: 24px;
   }
 
   @include media('>700px') {
@@ -16,10 +20,14 @@
 
 .intro {
   color: color('dimmed');
-  margin-top: 5px;
+  margin-top: 10px;
   margin-bottom: 5px;
 
-  @include media('>700px') {
+  @include media('<=700px') {
     font-size: 18px;
+  }
+
+  @include media('>700px') {
+    font-size: 20px;
   }
 }

--- a/src/components/ModalIntro/modal-intro.scss
+++ b/src/components/ModalIntro/modal-intro.scss
@@ -2,6 +2,7 @@
 
 .root {
   line-height: 1.3;
+  margin-bottom: 20px;
 }
 
 .title {

--- a/src/components/ModalWindow/modal-window.scss
+++ b/src/components/ModalWindow/modal-window.scss
@@ -31,12 +31,12 @@
   background-color: color('white');
   border-radius: 2px;
 
-  @include media('<=text-boost') {
-    padding: 20px;
+  @include media('<=modal-size') {
+    padding: 30px 20px;
   }
 
-  @include media('>text-boost') {
-    padding: 30px 50px;
+  @include media('>modal-size') {
+    padding: 50px;
   }
 }
 

--- a/src/components/PageTitle/page-title.scss
+++ b/src/components/PageTitle/page-title.scss
@@ -16,10 +16,11 @@
 }
 
 .intro {
-  @include responsive-font(3vw, 18px, 23px);
+  @include responsive-font(3vw, 18px, 22px);
   margin-top: 22px;
 }
 
 .lower {
+  @include responsive-font(3vw, 18px, 22px);
   padding-top: 5%;
 }

--- a/src/components/PetitionLink/index.js
+++ b/src/components/PetitionLink/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Link from 'components/Link';
+import getPetitionLink from 'helpers/getPetitionLink';
+
+const PetitionLink = ({ id }) => (
+  <Link href={getPetitionLink(id)} />
+);
+
+export default PetitionLink;

--- a/src/components/PetitionSidebar/index.js
+++ b/src/components/PetitionSidebar/index.js
@@ -4,16 +4,18 @@ import Countdown from 'components/Countdown';
 import SupportButton from 'containers/SupportButton';
 import TextCenter from 'components/TextCenter';
 
-const PetitionSidebar = ({ timeMetric }) => (
+const PetitionSidebar = ({ timeMetric, supportable }) => (
   <aside role='complementary' className={styles.root}>
     <div className={styles.counter}>
       <Countdown timeMetric={timeMetric} />
     </div>
-    <div className={styles.supportButton}>
-      <TextCenter>
-        <SupportButton />
-      </TextCenter>
-    </div>
+    {supportable &&
+      <div className={styles.supportButton}>
+        <TextCenter>
+          <SupportButton />
+        </TextCenter>
+      </div>
+    }
   </aside>
 );
 

--- a/src/components/PublishedPetition/index.js
+++ b/src/components/PublishedPetition/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import settings from 'settings';
 import Container from 'components/Container';
 import Header from 'components/Header';
-import PageTitle from 'components/PageTitle';
-import Link from 'components/Link';
 import Paragraph from 'components/Paragraph';
+import PageTitle from 'components/PageTitle';
+import PetitionLink from 'components/PetitionLink';
 import TextCenter from 'components/TextCenter';
 
 const PublishedPetition = ({ petition }) => (
@@ -19,10 +19,7 @@ const PublishedPetition = ({ petition }) => (
     </Header>
     <TextCenter>
       <Paragraph>
-        <Link
-          href={`${process.env.BASE_URL}/petitions/${petition.id}`}
-          text={`${process.env.BASE_URL}/petitions/${petition.id}`}
-        />
+        <PetitionLink id={petition.id} />
       </Paragraph>
     </TextCenter>
   </Container>

--- a/src/components/PublishedPetition/index.js
+++ b/src/components/PublishedPetition/index.js
@@ -3,7 +3,7 @@ import settings from 'settings';
 import Container from 'components/Container';
 import Header from 'components/Header';
 import PageTitle from 'components/PageTitle';
-import ButtonLink from 'components/ButtonLink';
+import Link from 'components/Link';
 import Paragraph from 'components/Paragraph';
 import TextCenter from 'components/TextCenter';
 
@@ -11,17 +11,17 @@ const PublishedPetition = ({ petition }) => (
   <Container>
     <Header>
       <PageTitle
-        title={settings.publishedPetitionPageTitle}
-        centered
-      />
+        title={settings.publishedPetitionPage.title}
+        intro={settings.publishedPetitionPage.intro}
+        centered>
+        <p>{settings.publishedPetitionPage.preview}</p>
+      </PageTitle>
     </Header>
     <TextCenter>
-      <Paragraph text={settings.publishedPetitionPage.copy1} />
       <Paragraph>
-        <ButtonLink
-          href={`/petitions/${petition.id}`}
-          text={'Preview your Petition'}
-          modifier={'accent'}
+        <Link
+          href={`${process.env.BASE_URL}/petitions/${petition.id}`}
+          text={`${process.env.BASE_URL}/petitions/${petition.id}`}
         />
       </Paragraph>
     </TextCenter>

--- a/src/components/ShareModal/index.js
+++ b/src/components/ShareModal/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styles from './share-modal.scss';
 import ModalIntro from 'components/ModalIntro';
+import Link from 'components/Link';
 import TextCenter from 'components/TextCenter';
 
 const ShareModal = ({ title, intro, link }) => (
@@ -10,7 +11,9 @@ const ShareModal = ({ title, intro, link }) => (
       intro={intro}
     />
     <TextCenter>
-      <a href={link} className={styles.link}>{link}</a>
+      <span className={styles.link}>
+        <Link href={link} text={link} />
+      </span>
     </TextCenter>
   </div>
 );

--- a/src/components/ShareModal/index.js
+++ b/src/components/ShareModal/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import styles from './share-modal.scss';
+import ModalIntro from 'components/ModalIntro';
+import TextCenter from 'components/TextCenter';
+
+const ShareModal = ({ title, intro, link }) => (
+  <div>
+    <ModalIntro
+      title={title}
+      intro={intro}
+    />
+    <TextCenter>
+      <a href={link} className={styles.link}>{link}</a>
+    </TextCenter>
+  </div>
+);
+
+export default ShareModal;

--- a/src/components/ShareModal/share-modal.scss
+++ b/src/components/ShareModal/share-modal.scss
@@ -1,0 +1,21 @@
+@import 'globals';
+
+.link {
+  display: inline-block;
+  margin-bottom: 10px;
+  font-size: 20px;
+  text-decoration: none;
+}
+
+.link:link,
+.link:visited {
+  color: color('black');
+  border-bottom: 1px solid color('grey');
+}
+
+.link:hover,
+.link:active,
+.link:focus {
+  color: color('primary');
+  border-bottom-color: color('primary');
+}

--- a/src/components/ShareModal/share-modal.scss
+++ b/src/components/ShareModal/share-modal.scss
@@ -1,21 +1,6 @@
 @import 'globals';
 
 .link {
-  display: inline-block;
   margin-bottom: 10px;
   font-size: 20px;
-  text-decoration: none;
-}
-
-.link:link,
-.link:visited {
-  color: color('black');
-  border-bottom: 1px solid color('grey');
-}
-
-.link:hover,
-.link:active,
-.link:focus {
-  color: color('primary');
-  border-bottom-color: color('primary');
 }

--- a/src/components/SsoProviders/sso-providers.scss
+++ b/src/components/SsoProviders/sso-providers.scss
@@ -1,7 +1,7 @@
 @import 'globals';
 
 .list {
-  margin-top: map-get($spacing, 'm-bottom');
+  // margin-top: map-get($spacing, 'm-bottom');
   display: inline-block;
   list-style: none;
 }

--- a/src/components/SupportButton/index.js
+++ b/src/components/SupportButton/index.js
@@ -8,7 +8,7 @@ const modal = {
   type: 'auth'
 };
 
-const SupportButton = ({ petition, supportable, supportPetition }) => (
+const SupportButton = ({ petition, supportPetition }) => (
   <ModalTrigger
     authenticating
     modal={modal}
@@ -17,7 +17,6 @@ const SupportButton = ({ petition, supportable, supportPetition }) => (
     text={settings.petitionPage.supportButton.text}
     size={'smaller'}
     modifier={'accent'}
-    disabled={!supportable}
   />
 );
 

--- a/src/components/SupportButton/index.js
+++ b/src/components/SupportButton/index.js
@@ -1,3 +1,4 @@
+
 import React from 'react';
 import ModalTrigger from 'containers/ModalTrigger';
 import settings from 'settings';

--- a/src/containers/ModalWindow.js
+++ b/src/containers/ModalWindow.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { hideModalWindow } from 'actions/ModalActions';
 import ModalWindow from 'components/ModalWindow';
 import LoginModal from 'components/LoginModal';
+import ShareModal from 'components/ShareModal';
 import generateSsoProviders from 'helpers/generateSsoProviders';
 
 const ModalWindowContainer = React.createClass({
@@ -33,22 +34,22 @@ const ModalWindowContainer = React.createClass({
   },
 
   render () {
-    const { type, title, intro, active, returnUrl, hideModalWindow } = this.props;
+    const { type, title, intro, link, active, returnUrl, hideModalWindow } = this.props;
     return (
       <ModalWindow active={active} hideModalWindow={hideModalWindow}>
         {type === 'auth' &&
           <LoginModal
-            type={type}
             title={title}
             intro={intro}
             ssoProviders={generateSsoProviders(returnUrl || '')}
           />
         }
-        {type === 'newlySupported' &&
-          <div>well done!</div>
-        }
-        {type === 'alreadySupported' &&
-          <div>you already supported!</div>
+        {type === 'supported' &&
+          <ShareModal
+            title={title}
+            intro={intro}
+            link={link}
+          />
         }
       </ModalWindow>
     );

--- a/src/containers/ModalWindow.js
+++ b/src/containers/ModalWindow.js
@@ -44,6 +44,9 @@ const ModalWindowContainer = React.createClass({
             ssoProviders={generateSsoProviders(returnUrl || '')}
           />
         }
+        {type === 'supported' &&
+          <div>well done!</div>
+        }
       </ModalWindow>
     );
   }

--- a/src/containers/ModalWindow.js
+++ b/src/containers/ModalWindow.js
@@ -44,8 +44,11 @@ const ModalWindowContainer = React.createClass({
             ssoProviders={generateSsoProviders(returnUrl || '')}
           />
         }
-        {type === 'supported' &&
+        {type === 'newlySupported' &&
           <div>well done!</div>
+        }
+        {type === 'alreadySupported' &&
+          <div>you already supported!</div>
         }
       </ModalWindow>
     );

--- a/src/containers/PetitionSidebar.js
+++ b/src/containers/PetitionSidebar.js
@@ -2,19 +2,20 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PetitionSidebar from 'components/PetitionSidebar';
 import getPetitionTimeMetrics from 'selectors/petitionTimeMetrics';
+import getPetionSupportable from 'selectors/petitionSupportable';
 
 const PetitionSidebarContainer = (props) => (
   <PetitionSidebar {...props} />
 );
 
-const mapStateToProps = ({ petition }) => {
-  return {
-    timeMetric: getPetitionTimeMetrics(petition)
-  };
-};
+const mapStateToProps = ({ petition }) => ({
+  timeMetric: getPetitionTimeMetrics(petition),
+  supportable: getPetionSupportable(petition)
+});
 
 PetitionSidebarContainer.propTypes = {
-  timeMetric: React.PropTypes.object
+  timeMetric: React.PropTypes.object,
+  supportable: React.PropTypes.bool
 };
 
 export default connect(

--- a/src/containers/Petitions.js
+++ b/src/containers/Petitions.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { fetchPetitions } from 'actions/PetitionActions';
-import { showModalWindow } from 'actions/ModalActions';
 import settings from 'settings';
 import Petitions from 'components/Petitions';
 import getPetitions from 'selectors/petitions';
@@ -44,8 +43,7 @@ export const mapStateToProps = ({ petitions }) => ({
 
 export const mapDispatchToProps = (dispatch) => {
   return {
-    fetchPetitions: (options) => dispatch(fetchPetitions(options)),
-    showModalWindow: () => dispatch(showModalWindow())
+    fetchPetitions: (options) => dispatch(fetchPetitions(options))
   };
 };
 

--- a/src/containers/Restricted.js
+++ b/src/containers/Restricted.js
@@ -16,7 +16,7 @@ const RestrictedWrapper = (WrappedComponent) => {
           );
         } else {
           router.goBack();
-          this.props.showModalWindow('auth', location);
+          this.props.showModalWindow({ type: 'auth' }, location);
         }
       }
     },

--- a/src/containers/SupportButton.js
+++ b/src/containers/SupportButton.js
@@ -1,16 +1,19 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { supportPetition } from 'actions/PetitionActions';
+import { showModalWindow } from 'actions/ModalActions';
 import getPetionSupportable from 'selectors/petitionSupportable';
 import SupportButton from 'components/SupportButton';
 
-const mapStateToProps = ({ petition }) => ({
+const mapStateToProps = ({ me, petition }) => ({
+  me,
   petition,
   supportable: getPetionSupportable(petition)
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  supportPetition: (petition) => dispatch(supportPetition(petition))
+  supportPetition: (petition) => dispatch(supportPetition(petition)),
+  showAuthModal: (petition) => dispatch(showModalWindow('auth', `/petitions/${petition.id}?intent=support`))
 });
 
 SupportButton.propTypes = {

--- a/src/containers/SupportButton.js
+++ b/src/containers/SupportButton.js
@@ -2,14 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { supportPetition } from 'actions/PetitionActions';
 import { showModalWindow } from 'actions/ModalActions';
-import getPetionSupportable from 'selectors/petitionSupportable';
 import SupportButton from 'components/SupportButton';
 
-const mapStateToProps = ({ me, petition }) => ({
-  me,
-  petition,
-  supportable: getPetionSupportable(petition)
-});
+const mapStateToProps = ({ me, petition }) => ({ me, petition });
 
 const mapDispatchToProps = (dispatch) => ({
   supportPetition: (petition) => dispatch(supportPetition(petition)),
@@ -18,7 +13,10 @@ const mapDispatchToProps = (dispatch) => ({
 
 SupportButton.propTypes = {
   petition: React.PropTypes.object,
-  supportable: React.PropTypes.bool
+  me: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.bool
+  ])
 };
 
 export default connect(

--- a/src/helpers/getPetitionLink.js
+++ b/src/helpers/getPetitionLink.js
@@ -1,0 +1,7 @@
+export default (id) => {
+  return [
+    process.env.BASE_URL,
+    'petitions',
+    id
+  ].join('/');
+};

--- a/src/helpers/getSupportedPetitionModal.js
+++ b/src/helpers/getSupportedPetitionModal.js
@@ -1,0 +1,12 @@
+import supportCountIncreased from 'helpers/supportCountIncreased';
+import settings from 'settings';
+
+export default (oldPetiton, newPetition) => {
+  const contentKey = supportCountIncreased(oldPetiton, newPetition)
+    ? 'newlySupported'
+    : 'alreadySupported';
+  return {
+    link: `${process.env.BASE_URL}/petitions/${newPetition.id}`,
+    ...settings.supportPetition[contentKey].modal
+  };
+};

--- a/src/helpers/getSupportedPetitionModal.js
+++ b/src/helpers/getSupportedPetitionModal.js
@@ -1,12 +1,13 @@
 import supportCountIncreased from 'helpers/supportCountIncreased';
 import settings from 'settings';
+import getPetitionLink from './getPetitionLink';
 
 export default (oldPetiton, newPetition) => {
   const contentKey = supportCountIncreased(oldPetiton, newPetition)
     ? 'newlySupported'
     : 'alreadySupported';
   return {
-    link: `${process.env.BASE_URL}/petitions/${newPetition.id}`,
+    link: getPetitionLink(newPetition.id),
     ...settings.supportPetition[contentKey].modal
   };
 };

--- a/src/helpers/supportCountIncreased.js
+++ b/src/helpers/supportCountIncreased.js
@@ -1,4 +1,5 @@
-export default (petition, updatedPetition) => {
-  return updatedPetition.supporters && updatedPetition.supporters.amount >
-    petition.supporters && petition.supporters.amount;
+export default (originalPetition, updatedPetition) => {
+  const originalSupport = originalPetition.supporters || {};
+  const updatedSupport = updatedPetition.supporters || {};
+  return updatedSupport.amount > originalSupport.amount;
 };

--- a/src/helpers/supportCountIncreased.js
+++ b/src/helpers/supportCountIncreased.js
@@ -1,0 +1,4 @@
+export default (petition, updatedPetition) => {
+  return updatedPetition.supporters && updatedPetition.supporters.amount >
+    petition.supporters && petition.supporters.amount;
+};

--- a/src/selectors/petition.js
+++ b/src/selectors/petition.js
@@ -1,4 +1,5 @@
 import getPetitionSchema from './petitionSchema';
+import getPetitionSupporters from './petitionSupporters';
 
 export default (petition = {}) => {
   if (!petition || !petition.id) {
@@ -8,6 +9,7 @@ export default (petition = {}) => {
   return {
     ...petition,
     browserTitle: petition.title,
-    schema: getPetitionSchema(petition)
+    schema: getPetitionSchema(petition),
+    supporters: getPetitionSupporters(petition)
   };
 };

--- a/src/selectors/petitionSupporters.js
+++ b/src/selectors/petitionSupporters.js
@@ -1,6 +1,5 @@
 export default (petition = {}) => {
   return {
-    id: petition.id,
     total: petition.supporters && petition.supporters.amount,
     required: petition.supporters && petition.supporters.required
   };

--- a/src/settings/config.js
+++ b/src/settings/config.js
@@ -29,7 +29,7 @@ export default {
     createButton: {
       text: 'Create a new Petition',
       modal: {
-        title: 'Log in required',
+        title: 'Please log in',
         intro: 'To begin creating your Petition please log in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
       }
     }
@@ -38,7 +38,7 @@ export default {
     supportButton: {
       text: 'Support Petition',
       modal: {
-        title: 'Thanks for your support',
+        title: 'Please log in',
         intro: 'In order to sign the Petition, we need you to log in using one of the services below..'
       }
     }
@@ -111,7 +111,7 @@ export default {
     afterLogoutPath: '/'
   },
   loginPage: {
-    title: 'Log in required',
+    title: 'Please log in',
     intro: 'To begin creating your Petition please log in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
   },
   flashMessages: {

--- a/src/settings/config.js
+++ b/src/settings/config.js
@@ -29,7 +29,7 @@ export default {
     createButton: {
       text: 'Create a new Petition',
       modal: {
-        title: 'One last step',
+        title: 'Log in required',
         intro: 'To begin creating your Petition please log in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
       }
     }
@@ -111,7 +111,7 @@ export default {
     afterLogoutPath: '/'
   },
   loginPage: {
-    title: 'One last step',
+    title: 'Log in required',
     intro: 'To begin creating your Petition please log in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
   },
   flashMessages: {

--- a/src/settings/config.js
+++ b/src/settings/config.js
@@ -82,6 +82,20 @@ export default {
       hint: 'Because you care a lot about your cause, you probably have some great ideas about how to solve it. Clearly outline the actions required to achieve your goal.'
     }
   },
+  supportPetition: {
+    newlySupported: {
+      modal: {
+        title: 'Thank you!',
+        intro: 'Now that you\'ve supported this petition, show even more support by sharing the link to anyone you know.'
+      }
+    },
+    alreadySupported: {
+      modal: {
+        title: 'Got it!',
+        intro: 'You\'ve already supported this petition, but go ahead and share the link to anyone you know.'
+      }
+    }
+  },
   ssoProviders: [
     {
       text: 'Sign in with AZ Medien',

--- a/src/settings/config.js
+++ b/src/settings/config.js
@@ -29,7 +29,8 @@ export default {
     createButton: {
       text: 'Create a new Petition',
       modal: {
-        intro: 'To begin creating your Petition please sign in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
+        title: 'One last step',
+        intro: 'To begin creating your Petition please log in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
       }
     }
   },
@@ -37,7 +38,8 @@ export default {
     supportButton: {
       text: 'Support Petition',
       modal: {
-        intro: 'To support a Petition please sign in using one of the services below. Afterwards, you woni\'t be required to enter any contact information.'
+        title: 'Thanks for your support',
+        intro: 'In order to sign the Petition, we need you to log in using one of the services below..'
       }
     }
   },
@@ -94,8 +96,8 @@ export default {
     afterLogoutPath: '/'
   },
   loginPage: {
-    title: 'Nearly There',
-    intro: 'Please sign in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
+    title: 'One last step',
+    intro: 'To begin creating your Petition please log in using one of the services below. Afterwards, you won\'t be required to enter any contact information.'
   },
   flashMessages: {
     genericError: 'Sadly something failed, please try again!',

--- a/src/settings/config.js
+++ b/src/settings/config.js
@@ -56,8 +56,9 @@ export default {
     saveButton: 'Save Petition'
   },
   publishedPetitionPage: {
-    title: 'Petition published',
-    copy1: 'Your petition will be visible within the next 48 hours after being approved by an editor. In the meantime, share your petition and start collecting signatures:',
+    title: 'Your petition was successfully published',
+    intro: 'It can already be supported and will appear online within 48 hours. Until then, why not share it with others to start gaining support?',
+    preview: 'To see your petition, click the following link:',
     previewButton: 'Preview your Petition'
   },
   petitionFields: {

--- a/test/helpers/supportCountIncreased.js
+++ b/test/helpers/supportCountIncreased.js
@@ -6,9 +6,9 @@ const { assert } = chai;
 describe('getIncludedAssetPath', () => {
   it('returns `false` when both totals are equal', () => {
     const actual = supportCountIncreased({
-      supporters: { total: 10 }
+      supporters: { amount: 10 }
     }, {
-      supporters: { total: 10 }
+      supporters: { amount: 10 }
     });
     const expected = false;
 
@@ -17,9 +17,9 @@ describe('getIncludedAssetPath', () => {
 
   it('returns `false` when updatedPetition total is less', () => {
     const actual = supportCountIncreased({
-      supporters: { total: 10 }
+      supporters: { amount: 10 }
     }, {
-      supporters: { total: 9 }
+      supporters: { amount: 9 }
     });
     const expected = false;
 
@@ -28,11 +28,11 @@ describe('getIncludedAssetPath', () => {
 
   it('returns `true` when updatedPetition total is higher', () => {
     const actual = supportCountIncreased({
-      supporters: { total: 10 }
+      supporters: { amount: 10 }
     }, {
-      supporters: { total: 11 }
+      supporters: { amount: 11 }
     });
-    const expected = false;
+    const expected = true;
 
     assert.equal(actual, expected);
   });

--- a/test/helpers/supportCountIncreased.js
+++ b/test/helpers/supportCountIncreased.js
@@ -1,0 +1,50 @@
+import chai from 'chai';
+import supportCountIncreased from 'helpers/supportCountIncreased';
+
+const { assert } = chai;
+
+describe('getIncludedAssetPath', () => {
+  it('returns `false` when both totals are equal', () => {
+    const actual = supportCountIncreased({
+      supporters: { total: 10 }
+    }, {
+      supporters: { total: 10 }
+    });
+    const expected = false;
+
+    assert.equal(actual, expected);
+  });
+
+  it('returns `false` when updatedPetition total is less', () => {
+    const actual = supportCountIncreased({
+      supporters: { total: 10 }
+    }, {
+      supporters: { total: 9 }
+    });
+    const expected = false;
+
+    assert.equal(actual, expected);
+  });
+
+  it('returns `true` when updatedPetition total is higher', () => {
+    const actual = supportCountIncreased({
+      supporters: { total: 10 }
+    }, {
+      supporters: { total: 11 }
+    });
+    const expected = false;
+
+    assert.equal(actual, expected);
+  });
+
+  it('returns `false` as a falback', () => {
+    const actual = supportCountIncreased({
+      supporters: {}
+    }, {
+      supporters: {}
+    });
+    const expected = false;
+
+    assert.equal(actual, expected);
+  });
+});

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -133,20 +133,4 @@ describe('petition repository', () => {
       ));
     });
   });
-
-  describe('support', () => {
-    let examplePetition = { id: exampleId, title: exampleTitle };
-    let expectedPathArgument = `/petitions/${exampleId}/event/support`;
-    let expectedMethodArgument = 'POST';
-
-    it('calls the API client with proper arguments', () => {
-      petitionRepository.support(examplePetition);
-
-      assert(ApiClient.request.calledWith(
-        expectedPathArgument,
-        null,
-        expectedMethodArgument
-      ));
-    });
-  });
 });

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -19,9 +19,8 @@ describe('petition repository', () => {
     let expectedPathArgument = '/petitions';
 
     context('without any argument', () => {
-      let expectedDataArgument = { offset: 0, limit: 12, resolve: 'city,owner' };
-
       it('calls the API client with default offset and limit', () => {
+        let expectedDataArgument = { offset: 0, limit: 12, resolve: 'city,owner' };
         petitionRepository.all();
 
         assert(ApiClient.request.calledWith(
@@ -32,9 +31,8 @@ describe('petition repository', () => {
     });
 
     context('with custom pagination argument', () => {
-      let expectedDataArgument = { offset: 10, limit: 10, resolve: 'city,owner' };
-
       it('calls the API client with proper offset and limit', () => {
+        let expectedDataArgument = { offset: 10, limit: 10, resolve: 'city,owner' };
         petitionRepository.all({ page: 2, limit: 10 });
 
         assert(ApiClient.request.calledWith(
@@ -131,6 +129,22 @@ describe('petition repository', () => {
       assert(ApiClient.request.calledWith(
         expectedPathArgument,
         expectedDataArgument,
+        expectedMethodArgument
+      ));
+    });
+  });
+
+  describe('support', () => {
+    let examplePetition = { id: exampleId, title: exampleTitle };
+    let expectedPathArgument = `/petitions/${exampleId}/event/support`;
+    let expectedMethodArgument = 'POST';
+
+    it('calls the API client with proper arguments', () => {
+      petitionRepository.support(examplePetition);
+
+      assert(ApiClient.request.calledWith(
+        expectedPathArgument,
+        null,
         expectedMethodArgument
       ));
     });


### PR DESCRIPTION
Improving UX and focussing on the success messages / flow of the app.

- [x] Add Modal window when user has voted, instead of flash
- [x] Add Modal window with different content when user has already voted and votes again

![screen shot 2016-09-02 at 17 55 55](https://cloud.githubusercontent.com/assets/447493/18209897/33b0f51e-7136-11e6-9d62-4841571e76f0.png)

![screen shot 2016-09-02 at 17 54 48](https://cloud.githubusercontent.com/assets/447493/18209880/197d4288-7136-11e6-9cb7-7d8a7dd6f96b.png)

![screen shot 2016-09-02 at 17 54 30](https://cloud.githubusercontent.com/assets/447493/18209877/160d622c-7136-11e6-9326-d141f24a193b.png)

Also includes:

- [x] Add proper success screen content for new petition

![screen shot 2016-09-02 at 17 55 04](https://cloud.githubusercontent.com/assets/447493/18209906/39ec9366-7136-11e6-9b8a-7b72fb6a0be5.png)
