### PR TITLE
Feature/fix supportable

### DIFF
--- a/src/components/PetitionSidebar/index.js
+++ b/src/components/PetitionSidebar/index.js
@@ -9,7 +9,7 @@ const PetitionSidebar = ({ timeMetric, supportable }) => (
     <div className={styles.counter}>
       <Countdown timeMetric={timeMetric} />
     </div>
-    {supportable && timeMetric && timeMetric.votingActive &&
+    {supportable &&
       <div className={styles.supportButton}>
         <TextCenter>
           <SupportButton />

--- a/src/selectors/petitionForm.js
+++ b/src/selectors/petitionForm.js
@@ -1,7 +1,10 @@
+import getPersisted from './petitionPersisted';
+import getPublished from './petitionPublished';
+
 export default (petition = {}) => {
   return {
     ...petition,
-    persisted: !!petition.id,
-    published: !!(petition.state && petition.state.parent === 'supportable')
+    persisted: getPersisted(petition),
+    published: getPublished(petition)
   };
 };

--- a/src/selectors/petitionPersisted.js
+++ b/src/selectors/petitionPersisted.js
@@ -1,0 +1,3 @@
+export default ({ id }) => {
+  return !!id;
+};

--- a/src/selectors/petitionPublished.js
+++ b/src/selectors/petitionPublished.js
@@ -1,0 +1,10 @@
+export default ({ state }) => {
+  switch (!!state && state.name) {
+    case false:
+    case 'draft':
+    case 'rejected':
+      return false;
+    default:
+      return true;
+  }
+};

--- a/src/selectors/petitionSupportable.js
+++ b/src/selectors/petitionSupportable.js
@@ -1,3 +1,3 @@
-export default (petition = {}) => {
-  return !!petition.state && petition.state.parent === 'supportable';
+export default ({ state }) => {
+  return !!state && state.parent === 'supportable';
 };

--- a/test/selectors/petitionPersisted.js
+++ b/test/selectors/petitionPersisted.js
@@ -1,0 +1,18 @@
+import { assert } from 'chai';
+import getPetionPersisted from 'selectors/petitionPersisted';
+
+describe('getPetionPersisted', () => {
+  context('with a new petition', () => {
+    const actual = getPetionPersisted({});
+    const expected = false;
+
+    it('returns false', () => assert.equal(actual, expected));
+  });
+
+  context('with a persisted petition', () => {
+    const actual = getPetionPersisted({id: 'someid'});
+    const expected = true;
+
+    it('returns true', () => assert.equal(actual, expected));
+  });
+});

--- a/test/selectors/petitionPublished.js
+++ b/test/selectors/petitionPublished.js
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import getPetionPublished from 'selectors/petitionPublished';
+
+describe('getPetionPublished', () => {
+  context('with a new petition', () => {
+    const actual = getPetionPublished({});
+    const expected = false;
+
+    it('returns false', () => assert.equal(actual, expected));
+  });
+
+  context('with a drafted petition', () => {
+    const actual = getPetionPublished({
+      state: { name: 'draft', parent: '' }
+    });
+    const expected = false;
+
+    it('returns false', () => assert.equal(actual, expected));
+  });
+
+  context('with a rejected petition', () => {
+    const actual = getPetionPublished({
+      state: { name: 'rejected', parent: '' }
+    });
+    const expected = false;
+
+    it('returns false', () => assert.equal(actual, expected));
+  });
+
+  context('with a supportable petition', () => {
+    const actual = getPetionPublished({
+      state: { name: 'supportable', parent: 'pending' }
+    });
+    const expected = true;
+
+    it('returns true', () => assert.equal(actual, expected));
+  });
+
+  context('with a processing petition', () => {
+    const actual = getPetionPublished({
+      state: { name: 'processing', parent: 'sendLetterRequested' }
+    });
+    const expected = true;
+
+    it('returns true', () => assert.equal(actual, expected));
+  });
+
+  context('with a closed petition', () => {
+    const actual = getPetionPublished({
+      state: { name: 'closed', parent: '' }
+    });
+    const expected = true;
+
+    it('returns true', () => assert.equal(actual, expected));
+  });
+
+  context('with a losing petition', () => {
+    const actual = getPetionPublished({
+      state: { name: 'loser', parent: '' }
+    });
+    const expected = true;
+
+    it('returns true', () => assert.equal(actual, expected));
+  });
+});
+


### PR DESCRIPTION
- Refactored three petition state related selectors for better reusability.
- Do not check for `timeMetric.votingActive` when rendering the support button, since all our newly created petitions are currently returning `supporters.required = 0`.

@mattberridge, @Tom-Bonnike, @artibella: Can we just keep the current check for supportability until the API returns proper values here?