### PR TITLE
Feature/allow nested api params

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "piping": "^0.3.2",
     "postcss-loader": "^0.9.1",
     "progressbar.js": "^1.0.1",
-    "query-params": "0.0.1",
     "react": "^15.2.0",
     "react-autosuggest": "^6.0.2",
     "react-dom": "^15.2.0",

--- a/src/helpers/encodeParams.js
+++ b/src/helpers/encodeParams.js
@@ -1,0 +1,30 @@
+const serializeParam = (prefix, param, value) => {
+  const prefixedParam = prefix ? `${prefix}[${param}]` : param;
+
+  if (typeof (value) === 'object') {
+    return Object.keys(value)
+      .map(key => serializeParam(prefixedParam, parseKey(key), value[key]))
+      .join('&');
+  } else {
+    return [prefixedParam, value].join('=');
+  }
+};
+
+const parseKey = (key) => {
+  return parseInt(key) >= 0
+    ? ''
+    : key;
+};
+
+export default (params) => {
+  switch (params) {
+    case null:
+    case 'undefined':
+    case {}:
+      return '';
+    default:
+      return typeof (params) === 'string'
+        ? params
+        : serializeParam(false, false, params);
+  }
+};

--- a/src/helpers/getPetitionsRequestParams.js
+++ b/src/helpers/getPetitionsRequestParams.js
@@ -15,6 +15,6 @@ export default ({ limit, page }) => {
       'loser',
       'processing.*',
       'closed'
-    ]
+    ].join(',')
   };
 };

--- a/src/services/api/client.js
+++ b/src/services/api/client.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import createApiUrl from 'helpers/createApiUrl';
-import queryParams from 'query-params';
+import encodeParams from 'helpers/encodeParams';
 
 const apiUrl = (requestPath) => {
   const prefix = process.env.API_URL;
@@ -18,7 +18,7 @@ export default {
 
     switch (method) {
       case 'GET':
-        const requestParams = queryParams.encode(data);
+        const requestParams = encodeParams(data);
 
         if (requestParams.length > 0) {
           requestPath += `?${requestParams}`;

--- a/test/helpers/encodeParams.js
+++ b/test/helpers/encodeParams.js
@@ -1,0 +1,32 @@
+import { assert } from 'chai';
+import encodeParams from 'helpers/encodeParams';
+
+describe('encodeParams', () => {
+  context('with a string argument', () => {
+    const actual = encodeParams('foo=bar');
+    const expected = 'foo=bar';
+
+    it('returns the original argument', () => assert.equal(actual, expected));
+  });
+
+  context('with an object argument', () => {
+    const actual = encodeParams({ foo: 'bar', baz: 42 });
+    const expected = 'foo=bar&baz=42';
+
+    it('returns the serialized argument', () => assert.equal(actual, expected));
+  });
+
+  context('with a nested object argument', () => {
+    const actual = encodeParams({ foo: { bar: { baz: 42 } } });
+    const expected = 'foo[bar][baz]=42';
+
+    it('returns the serialized argument', () => assert.equal(actual, expected));
+  });
+
+  context('with nested object and array arguments', () => {
+    const actual = encodeParams({ a: 1, b: '2', c: { d: '3' }, foo: ['bar', 'baz'] });
+    const expected = 'a=1&b=2&c[d]=3&foo[]=bar&foo[]=baz';
+
+    it('returns the serialized argument', () => assert.equal(actual, expected));
+  });
+});

--- a/test/services/api/client.js
+++ b/test/services/api/client.js
@@ -3,7 +3,7 @@ import moxios from 'moxios';
 import ApiClient from 'services/api/client';
 
 describe('API client', () => {
-  let exampleData = { a: 1, b: '2' };
+  let exampleData = { a: 1, b: '2', c: ['c1', 'c2'] };
 
   beforeEach(() => {
     moxios.install();
@@ -40,7 +40,7 @@ describe('API client', () => {
     });
 
     it('transforms data object to query string on GET requests', (done) => {
-      let expectedUrl = /\/test\?a=1&b=2$/;
+      let expectedUrl = /\/test\?a=1&b=2&c\[\]=c1&c\[\]=c2$/;
       let expectedData = '{}';
 
       ApiClient.request('/test', exampleData, 'GET').then((response) => {


### PR DESCRIPTION
- removed `query-params` package in favor of our own [`encodeParams`](https://github.com/iris-dni/iris-frontend/blob/695972b65baa60b65aee50af2e5e0d65fdcf1564/src/helpers/encodeParams.js) helper which knows how to handle nested array/object params
- found out that the API accepts comma separated values for array params only. So, while `state=supportable.active,supportable.winner` would work, `state[]=supportable.active&state[]=supportable.winner` wouldn't
- thus fixed `getPetitionsRequestParams` helper to return the `state` param in the proper comma separated form

Ping @mattberridge