### PR TITLE
Ensure use of https

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "good-console": "^6.1.2",
     "h2o2": "^5.1.0",
     "hapi": "^13.5.0",
+    "hapi-require-https": "^2.0.9",
     "inert": "^4.0.1",
     "inject-then": "^2.0.5",
     "json-loader": "^0.5.4",

--- a/src/server.js
+++ b/src/server.js
@@ -50,7 +50,14 @@ const h2o2 = {
   register: require('h2o2')
 };
 
-server.register([vision, good, inert, injectThen, h2o2], err => {
+/**
+ * Redirect all http requests to https
+ */
+const hapiRequireHttps = {
+  register: require('hapi-require-https')
+};
+
+server.register([vision, good, inert, injectThen, h2o2, hapiRequireHttps], err => {
   if (err) throw err; // something bad happened loading the plugins
 });
 


### PR DESCRIPTION
It redirects all http requests to https.
You need to use https urls for the `BASE_URL` and `API_URL` ENV variables.