### PR TITLE
Replaced petition react-router link with our own stylized Link component

### DIFF
--- a/src/components/PetitionInfo/index.js
+++ b/src/components/PetitionInfo/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './petition-info.scss';
 import IconAndInfo from 'components/IconAndInfo';
-import { Link } from 'react-router';
+import Link from 'components/Link';
 import { petitionsPath } from 'helpers/petitionUrls';
 
 const PetitionInfo = ({ owner, city, dateRange }) => (
@@ -17,7 +17,7 @@ const PetitionInfo = ({ owner, city, dateRange }) => (
     {city && city.label &&
       <li className={styles.item}>
         <IconAndInfo icon='Pin'>
-          <Link to={petitionsPath({ city })}>
+          <Link href={petitionsPath({ city })}>
             {city.label}
           </Link>
         </IconAndInfo>


### PR DESCRIPTION
@eschaefer => I don‘t really know if there‘s a downside to not using the react-router link, but we have our own Link component with style & hover state.
As long as we don‘t need to use the react-router‘s “activeClassName” property, I don‘t think it‘s that bad to not use it?