### PR TITLE
[RFR] Client-side Loading Changes

### DIFF
--- a/src/containers/Petition.js
+++ b/src/containers/Petition.js
@@ -41,7 +41,7 @@ const PetitionContainer = React.createClass({
             'innerHTML': JSON.stringify(petition.schema || {})
           }]}
         />
-        <Loading isLoading={petition.isLoading}>
+        <Loading isLoading={!petition.id || petition.isLoading}>
           <Petition {...petition} />
         </Loading>
       </div>

--- a/src/containers/Petitions.js
+++ b/src/containers/Petitions.js
@@ -24,7 +24,7 @@ const PetitionsContainer = withRouter(React.createClass({
       this.props.fetchPetitions(this.props);
     }
 
-    // Fetch the city to popular autocomplete
+    // Fetch the city to populate autocomplete
     this.props.fetchCity(this.props);
   },
 

--- a/src/containers/Petitions.js
+++ b/src/containers/Petitions.js
@@ -23,9 +23,6 @@ const PetitionsContainer = withRouter(React.createClass({
       !isEqual(this.props.params, this.props.routeParams)) {
       this.props.fetchPetitions(this.props);
     }
-
-    // Fetch the city to populate autocomplete
-    this.props.fetchCity(this.props);
   },
 
   componentWillReceiveProps (nextProps) {

--- a/src/containers/Petitions.js
+++ b/src/containers/Petitions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
+import { isEqual } from 'lodash/lang';
 import citySuggestionFormatter from 'helpers/citySuggestionFormatter';
 import getPetitionsPageTitle from 'helpers/getPetitionsPageTitle';
 import { petitionsPath } from 'helpers/petitionUrls';
@@ -16,16 +17,26 @@ import getPetitions from 'selectors/petitions';
 
 const PetitionsContainer = withRouter(React.createClass({
   componentWillMount () {
-    if (this.props.location.action === 'PUSH') {
+    // If there are no petitions, or deep compare filter params;
+    // if they have changed then we fetch petitions client-side
+    if (!this.props.petitions.length ||
+      !isEqual(this.props.params, this.props.routeParams)) {
       this.props.fetchPetitions(this.props);
     }
+
+    // Fetch the city to popular autocomplete
+    this.props.fetchCity(this.props);
   },
 
   componentWillReceiveProps (nextProps) {
-    if (this.props.location.pathname !== nextProps.location.pathname) {
+    // Deep compare filter params, if they have changes
+    // then we fetch petitions again client-side
+    if (!isEqual(this.props.params, nextProps.params)) {
       this.props.fetchPetitions(nextProps);
 
+      // If no city given in new props
       if (!nextProps.params.cityName) {
+        // Force clear autocomplete
         this.props.updateCurrentCity({});
       }
     }


### PR DESCRIPTION
- Removes FOUC when loading a petition client-side in place of loading screen (to be styled)
- Deep compares route and state params now, to see whether Petitions filters have changed, before fetching petitions