### PR TITLE
[RFR] Feature/check if petition was already supported by me

### DIFF
--- a/src/components/SupportButton/index.js
+++ b/src/components/SupportButton/index.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import ModalTrigger from 'containers/ModalTrigger';
 import settings from 'settings';
@@ -13,10 +12,11 @@ const SupportButton = ({ petition, supportPetition }) => (
     authenticating
     modal={modal}
     onClick={() => supportPetition(petition)}
-    href={`/petitions/${petition.id}?intent=support`}
+    href={!petition.supportedByMe && `/petitions/${petition.id}?intent=support`}
     text={settings.petitionPage.supportButton.text}
     size={'smaller'}
     modifier={'accent'}
+    disabled={petition.supportedByMe}
   />
 );
 

--- a/src/containers/SupportButton.js
+++ b/src/containers/SupportButton.js
@@ -3,8 +3,12 @@ import { connect } from 'react-redux';
 import { supportPetition } from 'actions/SupportActions';
 import { showModalWindow } from 'actions/ModalActions';
 import SupportButton from 'components/SupportButton';
+import getPetition from 'selectors/petition';
 
-const mapStateToProps = ({ me, petition }) => ({ me, petition });
+const mapStateToProps = ({ me, petition }) => ({
+  me,
+  petition: getPetition(petition)
+});
 
 const mapDispatchToProps = (dispatch) => ({
   supportPetition: (petition) => dispatch(supportPetition(petition)),

--- a/src/selectors/petition.js
+++ b/src/selectors/petition.js
@@ -10,6 +10,7 @@ export default (petition = {}) => {
     ...petition,
     browserTitle: petition.title,
     schema: getPetitionSchema(petition),
-    supporters: getPetitionSupporters(petition)
+    supporters: getPetitionSupporters(petition),
+    supportedByMe: petition.extensions && petition.extensions.supporting
   };
 };

--- a/src/services/api/repositories/petition.js
+++ b/src/services/api/repositories/petition.js
@@ -5,7 +5,7 @@ import path from 'path';
 export default {
   find: (id) => {
     const requestPath = path.join('/petitions', id.toString());
-    const requestParams = { resolve: 'city,owner' };
+    const requestParams = { resolve: 'city,owner', extend: 'supporting' };
     return ApiClient.request(requestPath, requestParams);
   },
 

--- a/test/mocks/petition.json
+++ b/test/mocks/petition.json
@@ -27,6 +27,9 @@
       "modified": "2016-01-28T02:54:33"
     },
     "description": "Sunt deleniti numquam sunt natus. Officia saepe et magni et dolor.\nCupiditate accusantium debitis magni adipisci. Sit et consectetur blanditiis occaecati ipsam rerum eligendi. Nulla molestias voluptas cumque error perspiciatis ratione.\nAsperiores ex est fugit qui ipsum facere. Ex unde maiores sint blanditiis sed aut optio. Assumenda quis asperiores enim nesciunt et earum ipsa.\nIste eum illum repudiandae quibusdam et deserunt. Labore nostrum hic sapiente quisquam possimus tempora. Quam aut eveniet tempore corrupti ratione amet.\nNumquam dolores id a blanditiis id. Cum mollitia est et possimus. Repudiandae aut in praesentium esse quod aut corporis natus.",
+    "extensions": {
+      "supporting": false
+    },
     "id": 2,
     "images": [],
     "links": [],

--- a/test/selectors/petition.js
+++ b/test/selectors/petition.js
@@ -1,0 +1,27 @@
+import { assert } from 'chai';
+import mockPetition from '../mocks/petition';
+import getPetition from 'selectors/petition';
+
+describe('getPetition', () => {
+  context('with a petition I have not supported yet', () => {
+    const petition = {
+      ...mockPetition.data,
+      extensions: { supporting: false }
+    };
+    const actual = getPetition(petition).supportedByMe;
+    const expected = false;
+
+    it('returns false', () => assert.equal(actual, expected));
+  });
+
+  context('with a petition I have already supported', () => {
+    const petition = {
+      ...mockPetition.data,
+      extensions: { supporting: true }
+    };
+    const actual = getPetition(petition).supportedByMe;
+    const expected = true;
+
+    it('returns true', () => assert.equal(actual, expected));
+  });
+});

--- a/test/selectors/petitionSupportable.js
+++ b/test/selectors/petitionSupportable.js
@@ -1,16 +1,16 @@
 import { assert } from 'chai';
-import getPetionSupportable from 'selectors/petitionSupportable';
+import getPetitionSupportable from 'selectors/petitionSupportable';
 
-describe('getPetionSupportable', () => {
+describe('getPetitionSupportable', () => {
   context('with a new petition', () => {
-    const actual = getPetionSupportable({});
+    const actual = getPetitionSupportable({});
     const expected = false;
 
     it('returns false', () => assert.equal(actual, expected));
   });
 
   context('with a published petition', () => {
-    const actual = getPetionSupportable({state: { name: 'pending', parent: 'supportable' }});
+    const actual = getPetitionSupportable({state: { name: 'pending', parent: 'supportable' }});
     const expected = true;
 
     it('returns true', () => assert.equal(actual, expected));

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -65,7 +65,18 @@ describe('petition repository', () => {
 
       petitionRepository.find(exampleId);
 
-      assert(ApiClient.request.calledWith(
+      assert(ApiClient.request.calledWithMatch(
+        expectedPathArgument,
+        expectedDataArgument
+      ));
+    });
+
+    it('requests the supporting extension', () => {
+      let expectedDataArgument = { extend: 'supporting' };
+
+      petitionRepository.find(exampleId);
+
+      assert(ApiClient.request.calledWithMatch(
         expectedPathArgument,
         expectedDataArgument
       ));


### PR DESCRIPTION
If queried with `?extend=supporting`, the API will return information if the current user has already supported a petition.

This PR adds a check for this property to disable the support button if necessary.

@Tom-Bonnike, @mattberridge 