### PR TITLE
[RFR] Implement respond API

### DIFF
--- a/src/actions/RespondActions.js
+++ b/src/actions/RespondActions.js
@@ -1,9 +1,17 @@
 import petitionRepository from 'services/api/repositories/petition';
+import solveResolvedObjects from 'helpers/solveResolvedObjects';
+import settings from 'settings';
 
 import {
   requestPetition,
-  receivePetition
+  receivePetition,
+  submittingPetition,
+  updatedPetition
 } from 'actions/PetitionActions';
+
+import {
+  showFlashMessage
+} from './FlashActions';
 
 export function fetchPetitionByResponseToken (responseToken) {
   return (dispatch, getState) => {
@@ -13,4 +21,17 @@ export function fetchPetitionByResponseToken (responseToken) {
         receivePetition(response.data)
       ));
   };
+}
+
+export function respondToPetition (petition, response, dispatch) {
+  dispatch(submittingPetition());
+  return petitionRepository.respond(petition, response)
+    .then((response) => {
+      const resolvedPetition = solveResolvedObjects(petition, response.data);
+      dispatch(updatedPetition(resolvedPetition));
+    }).then(() => dispatch(
+      showFlashMessage(settings.flashMessages.petitionUpdated, 'success')
+    )).catch(() => dispatch(
+      showFlashMessage(settings.flashMessages.genericError, 'error')
+    ));
 }

--- a/src/actions/RespondActions.js
+++ b/src/actions/RespondActions.js
@@ -1,0 +1,16 @@
+import petitionRepository from 'services/api/repositories/petition';
+
+import {
+  requestPetition,
+  receivePetition
+} from 'actions/PetitionActions';
+
+export function fetchPetitionByResponseToken (responseToken) {
+  return (dispatch, getState) => {
+    dispatch(requestPetition());
+    return petitionRepository.findByResponseToken(responseToken)
+      .then(response => dispatch(
+        receivePetition(response.data)
+      ));
+  };
+}

--- a/src/actions/RespondActions.js
+++ b/src/actions/RespondActions.js
@@ -1,5 +1,4 @@
 import petitionRepository from 'services/api/repositories/petition';
-import solveResolvedObjects from 'helpers/solveResolvedObjects';
 import settings from 'settings';
 
 import {
@@ -23,12 +22,11 @@ export function fetchPetitionByResponseToken (responseToken) {
   };
 }
 
-export function respondToPetition (petition, response, dispatch) {
+export function respondToPetition (response, dispatch) {
   dispatch(submittingPetition());
-  return petitionRepository.respond(petition, response)
+  return petitionRepository.respond(response)
     .then((response) => {
-      const resolvedPetition = solveResolvedObjects(petition, response.data);
-      dispatch(updatedPetition(resolvedPetition));
+      dispatch(updatedPetition(response.data));
     }).then(() => dispatch(
       showFlashMessage(settings.flashMessages.petitionUpdated, 'success')
     )).catch(() => dispatch(

--- a/src/services/api/client.js
+++ b/src/services/api/client.js
@@ -12,19 +12,22 @@ const apiUrl = (requestPath) => {
   return createApiUrl(prefix, requestPath);
 };
 
+export const GET = 'GET';
+export const POST = 'POST';
+
 export default {
-  request: (requestPath = '', data = {}, method = 'GET') => {
+  request: (requestPath = '', data = {}, method = GET) => {
     let payload = {};
 
     switch (method) {
-      case 'GET':
+      case GET:
         const requestParams = encodeParams(data);
 
         if (requestParams.length > 0) {
           requestPath += `?${requestParams}`;
         }
         break;
-      case 'POST':
+      case POST:
         if (data !== {}) {
           payload = { data: data };
         }

--- a/src/services/api/repositories/auth.js
+++ b/src/services/api/repositories/auth.js
@@ -1,4 +1,4 @@
-import ApiClient from 'services/api/client';
+import ApiClient, { POST } from 'services/api/client';
 
 /**
  * Fetch the current user's data
@@ -11,7 +11,7 @@ export const whoAmI = () => {
  * Logout the current user
  */
 export const logout = () => {
-  return ApiClient.request('/auth/logout', null, 'POST');
+  return ApiClient.request('/auth/logout', null, POST);
 };
 
 export default { whoAmI, logout };

--- a/src/services/api/repositories/petition.js
+++ b/src/services/api/repositories/petition.js
@@ -1,4 +1,4 @@
-import ApiClient from 'services/api/client';
+import ApiClient, { POST } from 'services/api/client';
 import getRequestParams from 'helpers/getPetitionsRequestParams';
 import path from 'path';
 
@@ -23,7 +23,7 @@ export default {
 
   create: (petition) => {
     const requestPath = '/petitions';
-    return ApiClient.request(requestPath, petition, 'POST');
+    return ApiClient.request(requestPath, petition, POST);
   },
 
   update: (petition) => {
@@ -34,21 +34,21 @@ export default {
       delete petition.city.data;
     }
 
-    return ApiClient.request(requestPath, petition, 'POST');
+    return ApiClient.request(requestPath, petition, POST);
   },
 
   publish: (petition) => {
     const requestPath = path.join('/petitions', petition.id.toString(), '/event/publish');
-    return ApiClient.request(requestPath, null, 'POST');
+    return ApiClient.request(requestPath, null, POST);
   },
 
   support: (petition) => {
     const requestPath = path.join('/petitions', petition.id.toString(), '/event/support');
-    return ApiClient.request(requestPath, {}, 'POST');
+    return ApiClient.request(requestPath, {}, POST);
   },
 
   respond: (petition, response) => {
     const requestPath = path.join('/petitions', petition.id.toString(), 'event/setFeedback');
-    return ApiClient.request(requestPath, response, 'POST');
+    return ApiClient.request(requestPath, response, POST);
   }
 };

--- a/src/services/api/repositories/petition.js
+++ b/src/services/api/repositories/petition.js
@@ -9,6 +9,12 @@ export default {
     return ApiClient.request(requestPath, requestParams);
   },
 
+  findByResponseToken: (responseToken) => {
+    const requestPath = path.join('/token/', responseToken, '/petitions');
+    const requestParams = { resolve: 'city,owner' };
+    return ApiClient.request(requestPath, requestParams);
+  },
+
   all: (options = {}) => {
     const requestPath = '/petitions';
     const requestParams = getRequestParams(options);

--- a/src/services/api/repositories/petition.js
+++ b/src/services/api/repositories/petition.js
@@ -45,5 +45,10 @@ export default {
   support: (petition) => {
     const requestPath = path.join('/petitions', petition.id.toString(), '/event/support');
     return ApiClient.request(requestPath, {}, 'POST');
+  },
+
+  respond: (petition, response) => {
+    const requestPath = path.join('/petitions', petition.id.toString(), 'event/setFeedback');
+    return ApiClient.request(requestPath, response, 'POST');
   }
 };

--- a/src/services/api/repositories/petition.js
+++ b/src/services/api/repositories/petition.js
@@ -47,8 +47,12 @@ export default {
     return ApiClient.request(requestPath, {}, POST);
   },
 
-  respond: (petition, response) => {
-    const requestPath = path.join('/petitions', petition.id.toString(), 'event/setFeedback');
-    return ApiClient.request(requestPath, response, POST);
+  respond: (response) => {
+    const requestPath = path.join('/petitions', response.petitionId.toString(), 'event/setFeedback');
+    const requestPayload = {
+      answer: response.answer,
+      token: response.token
+    };
+    return ApiClient.request(requestPath, requestPayload, POST);
   }
 };

--- a/test/actions/RespondActions.js
+++ b/test/actions/RespondActions.js
@@ -5,33 +5,39 @@ import mockPetition from '../mocks/petition';
 
 import {
   requestPetition,
-  receivePetition
+  receivePetition,
+  submittingPetition,
+  updatedPetition
 } from 'actions/PetitionActions';
 
 import {
-  fetchPetitionByResponseToken
+  fetchPetitionByResponseToken,
+  respondToPetition
 } from 'actions/RespondActions';
 
 describe('RespondActions', () => {
+  let dispatch;
+  let result;
+  let exampleResponseToken = '1C9LQ';
+
+  beforeEach(() => {
+    dispatch = sinon.spy();
+
+    moxios.install();
+  });
+
+  afterEach(() => {
+    moxios.uninstall();
+  });
+
   describe('fetchPetitionByResponseToken', () => {
-    let exampleResponseToken = '1C9LQ';
-    let dispatch;
-    let result;
-
     beforeEach(() => {
-      dispatch = sinon.spy();
-
-      moxios.install();
       moxios.stubRequest(/.*/, {
         status: 200,
         response: { data: mockPetition }
       });
 
       result = fetchPetitionByResponseToken(exampleResponseToken);
-    });
-
-    afterEach(() => {
-      moxios.uninstall();
     });
 
     it('returns a function that dispatches requestPetition()', () => {
@@ -42,6 +48,40 @@ describe('RespondActions', () => {
     it('returns a function that returns a promise that dispatches receivePetition()', done => {
       result(dispatch).then(() => {
         assert(dispatch.calledWith(receivePetition(mockPetition)));
+      }).then(done, done);
+    });
+  });
+
+  describe('respondToPetition', () => {
+    let examplePetition = mockPetition.data;
+    let exampleResponse = {
+      answer: {
+        text: 'Example answer',
+        name: 'Jane Doe, Mayor'
+      },
+      token: exampleResponseToken
+    };
+    let examplePetitionWithResponse = {
+      ...examplePetition,
+      city_answer: exampleResponse.answer
+    };
+
+    beforeEach(() => {
+      moxios.stubRequest(/.*/, {
+        status: 200,
+        response: { data: examplePetitionWithResponse }
+      });
+
+      result = respondToPetition(examplePetition, exampleResponse, dispatch);
+    });
+
+    it('dispatches submittingPetition()', () => {
+      assert(dispatch.calledWith(submittingPetition()));
+    });
+
+    it('returns a promise that dispatches updatedPetition() when done', done => {
+      result.then(() => {
+        assert(dispatch.calledWithMatch(updatedPetition(examplePetitionWithResponse)));
       }).then(done, done);
     });
   });

--- a/test/actions/RespondActions.js
+++ b/test/actions/RespondActions.js
@@ -59,6 +59,7 @@ describe('RespondActions', () => {
         text: 'Example answer',
         name: 'Jane Doe, Mayor'
       },
+      petitionId: examplePetition.id,
       token: exampleResponseToken
     };
     let examplePetitionWithResponse = {
@@ -71,16 +72,16 @@ describe('RespondActions', () => {
         status: 200,
         response: { data: examplePetitionWithResponse }
       });
-
-      result = respondToPetition(examplePetition, exampleResponse, dispatch);
     });
 
-    it('dispatches submittingPetition()', () => {
-      assert(dispatch.calledWith(submittingPetition()));
+    it('dispatches submittingPetition()', done => {
+      respondToPetition(exampleResponse, dispatch).then(() => {
+        assert(dispatch.calledWith(submittingPetition()));
+      }).then(done, done);
     });
 
     it('returns a promise that dispatches updatedPetition() when done', done => {
-      result.then(() => {
+      respondToPetition(exampleResponse, dispatch).then(() => {
         assert(dispatch.calledWithMatch(updatedPetition(examplePetitionWithResponse)));
       }).then(done, done);
     });

--- a/test/actions/RespondActions.js
+++ b/test/actions/RespondActions.js
@@ -1,0 +1,48 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import moxios from 'moxios';
+import mockPetition from '../mocks/petition';
+
+import {
+  requestPetition,
+  receivePetition
+} from 'actions/PetitionActions';
+
+import {
+  fetchPetitionByResponseToken
+} from 'actions/RespondActions';
+
+describe('RespondActions', () => {
+  describe('fetchPetitionByResponseToken', () => {
+    let exampleResponseToken = '1C9LQ';
+    let dispatch;
+    let result;
+
+    beforeEach(() => {
+      dispatch = sinon.spy();
+
+      moxios.install();
+      moxios.stubRequest(/.*/, {
+        status: 200,
+        response: { data: mockPetition }
+      });
+
+      result = fetchPetitionByResponseToken(exampleResponseToken);
+    });
+
+    afterEach(() => {
+      moxios.uninstall();
+    });
+
+    it('returns a function that dispatches requestPetition()', () => {
+      result(dispatch);
+      assert(dispatch.calledWith(requestPetition()));
+    });
+
+    it('returns a function that returns a promise that dispatches receivePetition()', done => {
+      result(dispatch).then(() => {
+        assert(dispatch.calledWith(receivePetition(mockPetition)));
+      }).then(done, done);
+    });
+  });
+});

--- a/test/mocks/petition.json
+++ b/test/mocks/petition.json
@@ -30,7 +30,7 @@
     "extensions": {
       "supporting": false
     },
-    "id": 2,
+    "id": "7UV7m",
     "images": [],
     "links": [],
     "owner": {

--- a/test/mocks/petitionOpenGraph.json
+++ b/test/mocks/petitionOpenGraph.json
@@ -9,7 +9,7 @@
   },
   {
     "property": "og:url",
-    "content": "http://localhost:8000/petitions/2"
+    "content": "http://localhost:8000/petitions/7UV7m"
   },
   {
     "property": "og:type",

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -152,23 +152,26 @@ describe('petition repository', () => {
   });
 
   describe('respond', () => {
-    let examplePetition = { id: exampleId, title: exampleTitle };
     let exampleResponse = {
       answer: {
         text: 'Example Answer',
         name: 'Jane Doe, Mayor'
       },
+      petitionId: exampleId,
       token: exampleResponseToken
     };
 
     let expectedPathArgument = `/petitions/${exampleId}/event/setFeedback`;
-    let expectedDataArgument = exampleResponse;
+    let expectedDataArgument = {
+      answer: exampleResponse.answer,
+      token: exampleResponse.token
+    };
     let expectedMethodArgument = 'POST';
 
     it('calls the API client with proper arguments', () => {
-      petitionRepository.respond(examplePetition, exampleResponse);
+      petitionRepository.respond(exampleResponse);
 
-      assert(ApiClient.request.calledWith(
+      assert(ApiClient.request.calledWithMatch(
         expectedPathArgument,
         expectedDataArgument,
         expectedMethodArgument

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -4,7 +4,8 @@ import ApiClient from 'services/api/client';
 import petitionRepository from 'services/api/repositories/petition';
 
 describe('petition repository', () => {
-  let exampleId = 777;
+  let exampleId = '7UV7m';
+  let exampleResponseToken = '1C9LQ';
   let exampleTitle = 'Example Petition';
 
   beforeEach(() => {
@@ -51,18 +52,12 @@ describe('petition repository', () => {
 
   describe('find', () => {
     let expectedPathArgument = `/petitions/${exampleId}`;
+    let expectedDataArgument = {
+      resolve: 'city,owner',
+      extend: 'supporting'
+    };
 
-    it('calls the API and returns the requested petition', () => {
-      petitionRepository.find(exampleId);
-
-      assert(ApiClient.request.calledWith(
-        expectedPathArgument
-      ));
-    });
-
-    it('resolves owner and city', () => {
-      let expectedDataArgument = { resolve: 'city,owner' };
-
+    it('calls the API client with proper arguments', () => {
       petitionRepository.find(exampleId);
 
       assert(ApiClient.request.calledWithMatch(
@@ -70,11 +65,16 @@ describe('petition repository', () => {
         expectedDataArgument
       ));
     });
+  });
 
-    it('requests the supporting extension', () => {
-      let expectedDataArgument = { extend: 'supporting' };
+  describe('findByResponseToken', () => {
+    let expectedPathArgument = `/token/${exampleResponseToken}/petitions`;
+    let expectedDataArgument = {
+      resolve: 'city,owner'
+    };
 
-      petitionRepository.find(exampleId);
+    it('calls the API client with proper arguments', () => {
+      petitionRepository.findByResponseToken(exampleResponseToken);
 
       assert(ApiClient.request.calledWithMatch(
         expectedPathArgument,

--- a/test/services/api/repositories/petition.js
+++ b/test/services/api/repositories/petition.js
@@ -150,4 +150,29 @@ describe('petition repository', () => {
       ));
     });
   });
+
+  describe('respond', () => {
+    let examplePetition = { id: exampleId, title: exampleTitle };
+    let exampleResponse = {
+      answer: {
+        text: 'Example Answer',
+        name: 'Jane Doe, Mayor'
+      },
+      token: exampleResponseToken
+    };
+
+    let expectedPathArgument = `/petitions/${exampleId}/event/setFeedback`;
+    let expectedDataArgument = exampleResponse;
+    let expectedMethodArgument = 'POST';
+
+    it('calls the API client with proper arguments', () => {
+      petitionRepository.respond(examplePetition, exampleResponse);
+
+      assert(ApiClient.request.calledWith(
+        expectedPathArgument,
+        expectedDataArgument,
+        expectedMethodArgument
+      ));
+    });
+  });
 });


### PR DESCRIPTION
- Add `fetchByResponseToken` to petition repository
- Add `respond` to petition repository
- Add `fetchByResponseToken` action
- Add `respondToPetitionAction` action
- Reuse `requestPetition`, `receivePetition`, `submittingPetition`, and `updatedPetition` from `PetitionActions` for response actions.