### PR TITLE
[RFR] Restrict Trust Routes

### DIFF
--- a/src/components/PetitionForm/index.js
+++ b/src/components/PetitionForm/index.js
@@ -23,7 +23,7 @@ const PetitionForm = ({ petition, openGraph, fields, handleSubmit, submitting })
       <Button
         text={settings.petitionForm[petition.persisted ? 'saveButton' : 'createButton'].text}
         modifier={'accent'}
-        disabled={openGraph.isLoading || submitting || (__CLIENT__ && !fields._meta.allValid)}
+        disabled={openGraph.isLoading || submitting || !fields._meta.allValid}
       />
     </Fieldset>
   </form>

--- a/src/containers/EditPetition.js
+++ b/src/containers/EditPetition.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
-import { fetchPetition } from 'actions/PetitionActions';
 import { updateSuggestionInputValue } from 'actions/AutocompleteActions';
 import settings from 'settings';
 import citySuggestionFormatter from 'helpers/citySuggestionFormatter';
@@ -24,10 +23,6 @@ const EditPetitionContainer = React.createClass({
     );
   }
 });
-
-EditPetitionContainer.fetchData = ({ store, params }) => {
-  return store.dispatch(fetchPetition(params.id));
-};
 
 export const mapStateToProps = ({ petition }) => ({
   petition: getPetitionForm(petition)

--- a/src/containers/FetchPetition.js
+++ b/src/containers/FetchPetition.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { fetchPetition } from 'actions/PetitionActions';
+import getPetition from 'selectors/petition';
+
+const FetchPetitionWrapper = (WrappedComponent) => {
+  const FetchPetition = ({ petition }) => (
+    <WrappedComponent petition={petition} />
+  );
+
+  FetchPetition.fetchData = ({ store, params }) => {
+    return store.dispatch(fetchPetition(params.id));
+  };
+
+  FetchPetition.propTypes = {
+    petition: React.PropTypes.object
+  };
+
+  const mapStateToProps = ({ petition }) => ({
+    petition: getPetition(petition)
+  });
+
+  return connect(
+    mapStateToProps,
+  )(FetchPetition);
+};
+
+export default FetchPetitionWrapper;

--- a/src/containers/Petition.js
+++ b/src/containers/Petition.js
@@ -63,8 +63,6 @@ export const mapStateToProps = ({ petition }) => ({
   petition: getPetition(petition)
 });
 
-// Add dispatchers to the component props,
-// for fetching the data _client side_
 export const mapDispatchToProps = (dispatch) => ({
   fetchPetition: (id) => dispatch(fetchPetition(id)),
   refreshPetition: (id) => dispatch(refreshPetition(id)),

--- a/src/containers/PreviewPetition.js
+++ b/src/containers/PreviewPetition.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { fetchPetition, publishPetition } from 'actions/PetitionActions';
+import { publishPetition } from 'actions/PetitionActions';
 import settings from 'settings';
 import PreviewPetition from 'components/PreviewPetition';
 import getPetitionForm from 'selectors/petitionForm';
@@ -17,10 +17,6 @@ const PreviewPetitionContainer = withRouter(React.createClass({
     );
   }
 }));
-
-PreviewPetitionContainer.fetchData = ({ store, params }) => {
-  return store.dispatch(fetchPetition(params.id));
-};
 
 export const mapStateToProps = ({ petition }) => ({
   petition: getPetitionForm(petition)

--- a/src/containers/RedirectIfPublished.js
+++ b/src/containers/RedirectIfPublished.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import { fetchPetition } from 'actions/PetitionActions';
+import getPetition from 'selectors/petition';
+import petitionPublished from 'selectors/petitionPublished';
+import petitionPath from 'selectors/petitionPath';
+
+const RedirectIfPublishedWrapper = (WrappedComponent) => {
+  const RedirectIfPublished = React.createClass({
+    componentWillMount () {
+      if (petitionPublished(this.props.petition)) {
+        this.props.push(petitionPath(this.props.petition));
+      }
+    },
+
+    render () {
+      return (
+        <WrappedComponent petition={this.props.petition} />
+      );
+    }
+  });
+
+  RedirectIfPublished.fetchData = ({ store, params }) => {
+    return store.dispatch(fetchPetition(params.id));
+  };
+
+  const mapStateToProps = ({ petition }) => ({
+    petition: getPetition(petition)
+  });
+
+  const mapDispatchToProps = (dispatch) => ({
+    push: (url) => dispatch(push(url))
+  });
+
+  return connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(RedirectIfPublished);
+};
+
+export default RedirectIfPublishedWrapper;

--- a/src/containers/RedirectIfUnsupportable.js
+++ b/src/containers/RedirectIfUnsupportable.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import { fetchPetition, refreshPetition } from 'actions/PetitionActions';
+import getPetition from 'selectors/petition';
+import petitionSupportable from 'selectors/petitionSupportable';
+import petitionUserSupport from 'selectors/petitionUserSupport';
+import petitionPath from 'selectors/petitionPath';
+
+const RedirectIfPublishedWrapper = (WrappedComponent) => {
+  const RedirectIfPublished = React.createClass({
+    componentWillMount () {
+      if (!petitionSupportable(this.props.petition)) {
+        this.props.push(petitionPath(this.props.petition));
+      }
+
+      this.props.refreshPetition(this.props.petition.id)
+        .then(({ petition }) => {
+          if (petitionUserSupport(petition)) {
+            this.props.push(petitionPath(this.props.petition));
+          }
+        });
+    },
+
+    render () {
+      return (
+        <WrappedComponent petition={this.props.petition} />
+      );
+    }
+  });
+
+  RedirectIfPublished.fetchData = ({ store, params }) => {
+    return store.dispatch(fetchPetition(params.id));
+  };
+
+  const mapStateToProps = ({ petition }) => ({
+    petition: getPetition(petition)
+  });
+
+  const mapDispatchToProps = (dispatch) => ({
+    push: (url) => dispatch(push(url)),
+    refreshPetition: (id) => dispatch(refreshPetition(id))
+  });
+
+  return connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(RedirectIfPublished);
+};
+
+export default RedirectIfPublishedWrapper;

--- a/src/containers/TrustPublish.js
+++ b/src/containers/TrustPublish.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { fetchPetition } from 'actions/PetitionActions';
 import settings from 'settings';
 import Trust from 'components/Trust';
 import getPetitionForm from 'selectors/petitionForm';
@@ -13,10 +12,6 @@ const TrustPublishContainer = (props) => (
     <Trust {...props} action={'publish'} />
   </div>
 );
-
-TrustPublishContainer.fetchData = ({ store, params }) => {
-  return store.dispatch(fetchPetition(params.id));
-};
 
 export const mapStateToProps = ({ petition, trust, me }) => ({
   petition: getPetitionForm(petition),

--- a/src/containers/TrustPublishConfirmation.js
+++ b/src/containers/TrustPublishConfirmation.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
-import { fetchPetition } from 'actions/PetitionActions';
 import settings from 'settings';
 import TrustConfirmation from 'components/TrustConfirmation';
 
@@ -11,10 +10,6 @@ const TrustPublishConfirmationContainer = (props) => (
     <TrustConfirmation {...props} action={'publish'} />
   </div>
 );
-
-TrustPublishConfirmationContainer.fetchData = ({ store, params }) => {
-  return store.dispatch(fetchPetition(params.id));
-};
 
 export const mapStateToProps = ({ petition }) => ({
   me: petition.owner

--- a/src/containers/TrustSupport.js
+++ b/src/containers/TrustSupport.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { fetchPetition } from 'actions/PetitionActions';
 import settings from 'settings';
 import Trust from 'components/Trust';
 import getPetitionForm from 'selectors/petitionForm';
@@ -13,10 +12,6 @@ const TrustSupportContainer = (props) => (
     <Trust {...props} action={'support'} />
   </div>
 );
-
-TrustSupportContainer.fetchData = ({ store, params }) => {
-  return store.dispatch(fetchPetition(params.id));
-};
 
 export const mapStateToProps = ({ petition, trust, me }) => ({
   petition: getPetitionForm(petition),

--- a/src/containers/TrustSupportConfirmation.js
+++ b/src/containers/TrustSupportConfirmation.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
-import { fetchPetition } from 'actions/PetitionActions';
 import settings from 'settings';
 import TrustConfirmation from 'components/TrustConfirmation';
 
@@ -11,10 +10,6 @@ const TrustSupportConfirmationContainer = (props) => (
     <TrustConfirmation {...props} action={'support'} />
   </div>
 );
-
-TrustSupportConfirmationContainer.fetchData = ({ store, params }) => {
-  return store.dispatch(fetchPetition(params.id));
-};
 
 export const mapStateToProps = ({ me }) => ({ me });
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,15 +7,15 @@ import getHistory from 'helpers/getHistory';
 
 import App from 'containers/App';
 import Home from 'containers/Home';
+import Imprint from 'components/Imprint';
 import LoginPage from 'containers/Login';
 import Logout from 'containers/Logout';
-import Petition from 'containers/Petition';
 import Petitions from 'containers/Petitions';
 import NewPetition from 'containers/NewPetition';
+import Petition from 'containers/Petition';
 import EditPetition from 'containers/EditPetition';
 import PreviewPetition from 'containers/PreviewPetition';
 import RespondToPetition from 'containers/RespondToPetition';
-import Imprint from 'components/Imprint';
 import TrustSupport from 'containers/TrustSupport';
 import TrustSupportConfirmation from 'containers/TrustSupportConfirmation';
 import TrustPublish from 'containers/TrustPublish';

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,7 +13,6 @@ import Petition from 'containers/Petition';
 import Petitions from 'containers/Petitions';
 import NewPetition from 'containers/NewPetition';
 import EditPetition from 'containers/EditPetition';
-// import PublishedPetition from 'containers/PublishedPetition';
 import PreviewPetition from 'containers/PreviewPetition';
 import RespondToPetition from 'containers/RespondToPetition';
 import Imprint from 'components/Imprint';
@@ -21,6 +20,7 @@ import TrustSupport from 'containers/TrustSupport';
 import TrustSupportConfirmation from 'containers/TrustSupportConfirmation';
 import TrustPublish from 'containers/TrustPublish';
 import TrustPublishConfirmation from 'containers/TrustPublishConfirmation';
+import RedirectIfPublished from 'containers/RedirectIfPublished';
 
 export default (props = {}) => (
   <Router
@@ -41,13 +41,13 @@ export default (props = {}) => (
       </Route>
       <Route path='petitions/new' component={NewPetition} />
       <Route path='petitions/:id' component={Petition} />
-      <Route path='petitions/:id/edit' component={EditPetition} />
-      <Route path='petitions/:id/preview' component={PreviewPetition} />
+      <Route path='petitions/:id/edit' component={RedirectIfPublished(EditPetition)} />
+      <Route path='petitions/:id/preview' component={RedirectIfPublished(PreviewPetition)} />
       <Route path='respond/:token' component={RespondToPetition} />
       <Route path='trust/support/:id' component={TrustSupport} />
       <Route path='trust/support/:id/confirm' component={TrustSupportConfirmation} />
-      <Route path='trust/publish/:id' component={TrustPublish} />
-      <Route path='trust/publish/:id/confirm' component={TrustPublishConfirmation} />
+      <Route path='trust/publish/:id' component={RedirectIfPublished(TrustPublish)} />
+      <Route path='trust/publish/:id/confirm' component={RedirectIfPublished(TrustPublishConfirmation)} />
     </Route>
   </Router>
 );

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,7 +20,9 @@ import TrustSupport from 'containers/TrustSupport';
 import TrustSupportConfirmation from 'containers/TrustSupportConfirmation';
 import TrustPublish from 'containers/TrustPublish';
 import TrustPublishConfirmation from 'containers/TrustPublishConfirmation';
+// Restrictive higher-order components
 import RedirectIfPublished from 'containers/RedirectIfPublished';
+import RedirectIfUnsupportable from 'containers/RedirectIfUnsupportable';
 
 export default (props = {}) => (
   <Router
@@ -44,8 +46,8 @@ export default (props = {}) => (
       <Route path='petitions/:id/edit' component={RedirectIfPublished(EditPetition)} />
       <Route path='petitions/:id/preview' component={RedirectIfPublished(PreviewPetition)} />
       <Route path='respond/:token' component={RespondToPetition} />
-      <Route path='trust/support/:id' component={TrustSupport} />
-      <Route path='trust/support/:id/confirm' component={TrustSupportConfirmation} />
+      <Route path='trust/support/:id' component={RedirectIfUnsupportable(TrustSupport)} />
+      <Route path='trust/support/:id/confirm' component={RedirectIfUnsupportable(TrustSupportConfirmation)} />
       <Route path='trust/publish/:id' component={RedirectIfPublished(TrustPublish)} />
       <Route path='trust/publish/:id/confirm' component={RedirectIfPublished(TrustPublishConfirmation)} />
     </Route>


### PR DESCRIPTION
Using Higher Order Component conventions we had already used elsewhere (`Restricted` container) and outlined from here:
https://crysislinux.com/limit-access-to-redux-apps-with-higher-order-components/

We restrict access to the `/trust/support/:id` routes if the petition is unsupportable, or if the user has already supported (client-side test)

We restrict access to the `/trust/publish/:id`, `/petitions/:id/edit` and `/petition/:id/preview`routes if the petition is already published.

I quite like this idea of using HOCs to do data fetching and restricting. Means again we can abstract things using the React component lifecycle.

Also note the use of `{ push }` i.e .`dispatch(push)` with `react-router-redux`. We have used elsewhere `withRouter()` and `this.props.router.push`.