### PR TITLE
[RFR] Owner Relation Display

### DIFF
--- a/src/selectors/petitionOwner.js
+++ b/src/selectors/petitionOwner.js
@@ -1,11 +1,12 @@
 import { get } from 'lodash/object';
 
 export default (petition = {}) => {
-  if (petition.owner) {
-    return [
-      get(petition, 'owner.firstname') || get(petition, 'owner.data.firstname'),
-      get(petition, 'owner.lastname') || get(petition, 'owner.data.lastname')
-    ].join(' ');
+  const firstname = get(petition, 'owner.firstname') || get(petition, 'owner.data.firstname');
+  const lastname = get(petition, 'owner.lastname') || get(petition, 'owner.data.lastname');
+
+  if (petition.owner && (firstname || lastname)) {
+    return [firstname, lastname].join(' ');
   }
+
   return '';
 };

--- a/src/selectors/petitionOwner.js
+++ b/src/selectors/petitionOwner.js
@@ -1,8 +1,10 @@
+import { get } from 'lodash/object';
+
 export default (petition = {}) => {
-  if (petition.owner && petition.owner.data) {
+  if (petition.owner) {
     return [
-      petition.owner.data.firstname,
-      petition.owner.data.lastname
+      get(petition, 'owner.firstname') || get(petition, 'owner.data.firstname'),
+      get(petition, 'owner.lastname') || get(petition, 'owner.data.lastname')
     ].join(' ');
   }
   return '';

--- a/src/selectors/petitionOwner.js
+++ b/src/selectors/petitionOwner.js
@@ -5,7 +5,7 @@ export default (petition = {}) => {
   const lastname = get(petition, 'owner.lastname') || get(petition, 'owner.data.lastname');
 
   if (petition.owner && (firstname || lastname)) {
-    return [firstname, lastname].join(' ');
+    return [firstname, lastname].join(' ').trim();
   }
 
   return '';

--- a/test/selectors/petitionOwner.js
+++ b/test/selectors/petitionOwner.js
@@ -5,7 +5,23 @@ import mockPetition from '../mocks/petition';
 const { assert } = chai;
 
 describe('petitionOwner selector', () => {
-  it('returns name correctly', () => {
+  it('returns name from base object primarily', () => {
+    const testOwnerPetition = {
+      ...mockPetition.data,
+      owner: {
+        ...mockPetition.data.owner,
+        firstname: 'Overwritten',
+        lastname: 'Name'
+      }
+    };
+
+    const actual = getPetitionOwner(testOwnerPetition);
+    const expected = 'Overwritten Name';
+
+    assert.equal(actual, expected);
+  });
+
+  it('returns name from `data` object otherwise', () => {
     const actual = getPetitionOwner(mockPetition.data);
     const expected = 'Stephanie Ballard';
 


### PR DESCRIPTION
**Bug from review**: call petition owner from base object first, then `data` nested object if not present. So non-SSO petitions always display an author name (they don't have nested `data`)

![screen shot 2016-10-21 at 12 55 40](https://cloud.githubusercontent.com/assets/447493/19596203/b44c34b8-978d-11e6-9050-f9774ed946b5.png)
![screen shot 2016-10-21 at 12 55 24](https://cloud.githubusercontent.com/assets/447493/19596201/b444b8fa-978d-11e6-86dc-6f6643181485.png)
