### PR TITLE
Skip img srcSet and sizes if given srcSet is empty

### DIFF
--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import styles from './image.scss';
 import createSignedImageUrl from 'helpers/createSignedImageUrl';
-import createSrcSet from 'helpers/createSrcSet';
+import createResponsiveImageAttributes from 'helpers/createResponsiveImageAttributes';
 
 const Image = ({ src, srcSet = [], attrs, sizes, alt }) => (
   <img className={styles.root}
     src={attrs ? createSignedImageUrl(src, attrs) : src}
-    srcSet={srcSet.length ? createSrcSet(src, attrs, srcSet) : ''}
-    sizes={sizes || ''}
     alt={alt || ''}
+
+    {...createResponsiveImageAttributes(src, srcSet, attrs, sizes)}
   />
 );
 

--- a/src/helpers/createResponsiveImageAttributes.js
+++ b/src/helpers/createResponsiveImageAttributes.js
@@ -1,0 +1,12 @@
+import createSrcSet from 'helpers/createSrcSet';
+
+export default (src = '', srcSet = [], attrs = {}, sizes = '') => {
+  if (srcSet.length) {
+    return {
+      srcSet: createSrcSet(src, attrs, srcSet),
+      sizes: sizes
+    };
+  }
+
+  return {};
+};

--- a/test/helpers/createResponsiveImageAttributes.js
+++ b/test/helpers/createResponsiveImageAttributes.js
@@ -1,0 +1,26 @@
+import chai from 'chai';
+import createResponsiveImageAttributes from 'helpers/createResponsiveImageAttributes';
+
+const { assert } = chai;
+
+describe('ResponsiveImageAttributes', () => {
+  const baseUrl = 'https://test.com/?url=/4891e30ddceb44008b252cb5ff9ac6bc';
+  const srcSet = [200, 400, 800];
+  const attrs = { w: 200, h: 400 };
+  const sizes = '(min-width: 900px) 320px, (min-width: 600px) 50vw, 100vw';
+  const expectedSrcSet = 'http://localhost:8000/images?domain=https://test.com/&url=/4891e30ddceb44008b252cb5ff9ac6bc&w=200&h=400 200w, http://localhost:8000/images?domain=https://test.com/&url=/4891e30ddceb44008b252cb5ff9ac6bc&w=400&h=800 400w, http://localhost:8000/images?domain=https://test.com/&url=/4891e30ddceb44008b252cb5ff9ac6bc&w=800&h=1600 800w';
+
+  it('returns srcSet and sizes if srcSet was given', () => {
+    const actual = createResponsiveImageAttributes(baseUrl, srcSet, attrs, sizes);
+    const expected = { srcSet: expectedSrcSet, sizes: sizes };
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('returns an empty object if srcSet was empty', () => {
+    const actual = createResponsiveImageAttributes(baseUrl, [], attrs, sizes);
+    const expected = {};
+
+    assert.deepEqual(actual, expected);
+  });
+});


### PR DESCRIPTION
@mattberridge HTML validators complain about empty `srcSet`  and `sizes` attributes for images that only have one `src` like for instance the publisher logos in petitio's footer section.

So I added a new helper method `createResponsiveImageAttributes` that returns an empty object of the `srcSet` argument in empty.