### PR TITLE
Remove latest petition teasers on homepage

### DIFF
--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -19,12 +19,6 @@ const MODULES = [
     }
   },
   {
-    component: 'PetitionGroup',
-    props: {
-      group: 'trending'
-    }
-  },
-  {
     component: 'CallToAction',
     props: {
       ...settings.aboutCTA
@@ -33,7 +27,7 @@ const MODULES = [
   {
     component: 'PetitionGroup',
     props: {
-      group: 'latest'
+      group: 'trending'
     }
   },
   {


### PR DESCRIPTION
As there was much overlap between latest and trending petitions teasers when not a lot of new petitions were created. So we decided to ditch the latest petitions teasers on the homepage.